### PR TITLE
NoOps + Refactoring of CFG adjacency matrix

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/cfg/AdjacencyMatrix.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/AdjacencyMatrix.java
@@ -1,0 +1,322 @@
+package it.unive.lisa.cfg;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import it.unive.lisa.cfg.edge.Edge;
+import it.unive.lisa.cfg.edge.FalseEdge;
+import it.unive.lisa.cfg.edge.SequentialEdge;
+import it.unive.lisa.cfg.edge.TrueEdge;
+import it.unive.lisa.cfg.statement.NoOp;
+import it.unive.lisa.cfg.statement.Statement;
+import it.unive.lisa.util.collections.ExternalSet;
+import it.unive.lisa.util.collections.ExternalSetCache;
+
+/**
+ * An adjacency matrix for a graph that has {@link Statement}s as nodes and
+ * {@link Edge}s as edges. It is represented as a map between a statement and a
+ * {@link Pair} of set of edges, where the {@link Pair#getLeft()} yields the set
+ * of ingoing edges and {@link Pair#getRight()} yields the set of outgoing
+ * edges. Set of edges are represented as {@link ExternalSet}s derived from a
+ * matrix-unique {@link ExternalSetCache}.
+ * 
+ * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
+ */
+public class AdjacencyMatrix implements Iterable<Map.Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>>> {
+
+	/**
+	 * The factory where edges are stored.
+	 */
+	private ExternalSetCache<Edge> edgeFactory;
+
+	/**
+	 * The matrix. The left set in the mapped value is the set of ingoing edges,
+	 * while the right one is the set of outgoing edges.
+	 */
+	private Map<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> matrix;
+
+	/**
+	 * Builds a new matrix.
+	 */
+	public AdjacencyMatrix() {
+		edgeFactory = new ExternalSetCache<>();
+		matrix = new ConcurrentHashMap<>();
+	}
+
+	/**
+	 * Copies the given matrix by keeping the same edge {@link ExternalSetCache},
+	 * shallow-copying the {@link Statement}s and deep-copying the values.
+	 * 
+	 * @param other the matrix to copy
+	 */
+	public AdjacencyMatrix(AdjacencyMatrix other) {
+		edgeFactory = other.edgeFactory;
+		matrix = new ConcurrentHashMap<>();
+		for (Map.Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> entry : other.matrix.entrySet())
+			matrix.put(entry.getKey(), Pair.of(entry.getValue().getLeft().copy(), entry.getValue().getRight().copy()));
+	}
+
+	/**
+	 * Adds the given node to the set of nodes.
+	 * 
+	 * @param node the node to add
+	 */
+	public void addNode(Statement node) {
+		matrix.put(node, Pair.of(edgeFactory.mkEmptySet(), edgeFactory.mkEmptySet()));
+	}
+
+	/**
+	 * Yields the collection of nodes of this matrix.
+	 * 
+	 * @return the collection of nodes
+	 */
+	public final Collection<Statement> getNodes() {
+		return matrix.keySet();
+	}
+
+	/**
+	 * Adds an edge to this matrix
+	 * 
+	 * @param e the edge to add
+	 * @throws UnsupportedOperationException if the source or the destination of the
+	 *                                       given edge are not part of this matrix
+	 */
+	public void addEdge(Edge e) {
+		if (!matrix.containsKey(e.getSource()))
+			throw new UnsupportedOperationException("The source node is not in the graph");
+
+		if (!matrix.containsKey(e.getDestination()))
+			throw new UnsupportedOperationException("The destination node is not in the graph");
+
+		matrix.get(e.getSource()).getRight().add(e);
+		matrix.get(e.getDestination()).getLeft().add(e);
+	}
+
+	/**
+	 * Yields the edge connecting the two given statements, if any. Yields
+	 * {@code null} if such edge does not exist, or if one of the two statements is
+	 * not inside this matrix.
+	 * 
+	 * @param source      the source statement
+	 * @param destination the destination statement
+	 * @return the edge connecting {@code source} to {@code destination}, or
+	 *         {@code null}
+	 */
+	public final Edge getEdgeConnecting(Statement source, Statement destination) {
+		if (!matrix.containsKey(source))
+			return null;
+
+		for (Edge e : matrix.get(source).getRight())
+			if (e.getDestination().equals(destination))
+				return e;
+
+		return null;
+	}
+
+	/**
+	 * Yields the set of edges of this matrix.
+	 * 
+	 * @return the collection of edges
+	 */
+	public final Collection<Edge> getEdges() {
+		return matrix.values().stream()
+				.flatMap(c -> Stream.concat(c.getLeft().collect().stream(), c.getRight().collect().stream()))
+				.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Yields the collection of the nodes that are followers of the given one, that
+	 * is, all nodes such that there exist an edge in this matrix going from the
+	 * given node to such node. Yields {@code null} if the node is not in this
+	 * matrix.
+	 * 
+	 * @param node the node
+	 * @return the collection of followers
+	 */
+	public final Collection<Statement> followersOf(Statement node) {
+		if (!matrix.containsKey(node))
+			return null;
+
+		return matrix.get(node).getRight().collect().stream().map(e -> e.getDestination()).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Yields the collection of the nodes that are predecessors of the given vertex,
+	 * that is, all nodes such that there exist an edge in this matrix going from
+	 * such node to the given one. Yields {@code null} if the node is not in this
+	 * matrix.
+	 * 
+	 * @param node the node
+	 * @return the collection of predecessors
+	 */
+	public final Collection<Statement> predecessorsOf(Statement node) {
+		if (!matrix.containsKey(node))
+			return null;
+
+		return matrix.get(node).getLeft().collect().stream().map(e -> e.getSource()).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Simplifies this matrix, removing all {@link NoOp}s and rewriting the edge set
+	 * accordingly. This method will throw an {@link UnsupportedOperationException}
+	 * if one of the {@link NoOp}s has an outgoing edge that is not a
+	 * {@link SequentialEdge}, since such statement is expected to always be
+	 * sequential.
+	 * 
+	 * @throws UnsupportedOperationException if there exists at least one
+	 *                                       {@link NoOp} with an outgoing
+	 *                                       non-sequential edge, or if one of the
+	 *                                       ingoing edges to the {@link NoOp} is
+	 *                                       not currently supported.
+	 */
+	public synchronized void simplify() {
+		Set<Statement> noops = matrix.keySet().stream().filter(k -> k instanceof NoOp).collect(Collectors.toSet());
+		for (Statement noop : noops) {
+			for (Edge ingoing : matrix.get(noop).getLeft())
+				for (Edge outgoing : matrix.get(noop).getRight()) {
+					if (!(outgoing instanceof SequentialEdge))
+						throw new UnsupportedOperationException(
+								"Cannot remove no-op with non-sequential outgoing edge");
+
+					// replicate the edge from ingoing.source to outgoing.dest
+					Edge _new = null;
+					if (ingoing instanceof SequentialEdge)
+						_new = new SequentialEdge(ingoing.getSource(), outgoing.getDestination());
+					else if (ingoing instanceof TrueEdge)
+						_new = new TrueEdge(ingoing.getSource(), outgoing.getDestination());
+					else if (ingoing instanceof FalseEdge)
+						_new = new FalseEdge(ingoing.getSource(), outgoing.getDestination());
+					else
+						throw new UnsupportedOperationException("Unknown edge type: " + ingoing.getClass().getName());
+
+					matrix.get(ingoing.getSource()).getRight().remove(ingoing);
+					matrix.get(ingoing.getSource()).getRight().add(_new);
+					matrix.get(outgoing.getDestination()).getLeft().remove(outgoing);
+					matrix.get(outgoing.getDestination()).getLeft().add(_new);
+				}
+			matrix.remove(noop);
+		}
+	}
+
+	@Override
+	public Iterator<Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>>> iterator() {
+		return matrix.entrySet().iterator();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((matrix == null) ? 0 : matrix.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AdjacencyMatrix other = (AdjacencyMatrix) obj;
+		if (matrix == null) {
+			if (other.matrix != null)
+				return false;
+		} else if (!matrix.equals(other.matrix))
+			return false;
+		return true;
+	}
+
+	/**
+	 * Checks if this matrix is effectively equal to the given one, that is, if they
+	 * have the same structure while potentially being different instances.
+	 * 
+	 * @param other the other matrix
+	 * @return {@code true} if this matrix and the given one are effectively equals
+	 */
+	public boolean isEqualTo(AdjacencyMatrix other) {
+		if (this == other)
+			return true;
+		if (other == null)
+			return false;
+		if (matrix == null) {
+			if (other.matrix != null)
+				return false;
+		} else if (!areEqual(matrix, other.matrix))
+			return false;
+		return true;
+	}
+
+	private static boolean areEqual(Map<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> first,
+			Map<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> second) {
+		// the following keeps track of the unmatched statements in second
+		Collection<Statement> copy = new HashSet<>(second.keySet());
+		boolean found;
+		for (Map.Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> entry : first.entrySet()) {
+			found = false;
+			for (Map.Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> entry2 : second.entrySet())
+				if (copy.contains(entry2.getKey()) && entry.getKey().isEqualTo(entry2.getKey())
+						&& areEqual(entry.getValue().getLeft(), entry2.getValue().getLeft())
+						&& areEqual(entry.getValue().getRight(), entry2.getValue().getRight())) {
+					copy.remove(entry2.getKey());
+					found = true;
+					break;
+				}
+			if (!found)
+				return false;
+		}
+
+		if (!copy.isEmpty())
+			// we also have to match all of the entrypoints in cfg.entrypoints
+			return false;
+
+		return true;
+	}
+
+	private static boolean areEqual(ExternalSet<Edge> first, ExternalSet<Edge> second) {
+		// the following keeps track of the unmatched statements in second
+		Collection<Edge> copy = second.collect();
+		boolean found;
+		for (Edge e : first) {
+			found = false;
+			for (Edge ee : second)
+				if (copy.contains(ee) && e.isEqualTo(ee)) {
+					copy.remove(ee);
+					found = true;
+					break;
+				}
+			if (!found)
+				return false;
+		}
+
+		if (!copy.isEmpty())
+			// we also have to match all of the entrypoints in cfg.entrypoints
+			return false;
+
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder res = new StringBuilder();
+		for (Map.Entry<Statement, Pair<ExternalSet<Edge>, ExternalSet<Edge>>> entry : this) {
+			res.append("\"").append(entry.getKey()).append("\" -> [\n\tingoing: ");
+			res.append(StringUtils.join(entry.getValue().getLeft(), ", "));
+			res.append("\n\toutgoing: ");
+			res.append(StringUtils.join(entry.getValue().getRight(), ", "));
+			res.append("\n]\n");
+		}
+		return res.toString();
+	}
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/edge/Edge.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/edge/Edge.java
@@ -1,4 +1,4 @@
-package it.unive.lisa.cfg;
+package it.unive.lisa.cfg.edge;
 
 import it.unive.lisa.cfg.statement.Statement;
 
@@ -54,6 +54,7 @@ public abstract class Edge {
 		int result = 1;
 		result = prime * result + ((destination == null) ? 0 : destination.hashCode());
 		result = prime * result + ((source == null) ? 0 : source.hashCode());
+		result = prime * result + getClass().getName().hashCode();
 		return result;
 	}
 
@@ -79,8 +80,36 @@ public abstract class Edge {
 		return true;
 	}
 
-	@Override
-	public String toString() {
-		return "[ " + source + " ] -> [ " + destination + " ]";
+	/**
+	 * Checks if this edge is effectively equal to the given one, that is, if they
+	 * have the same structure while potentially being different instances. This
+	 * translates into comparing source and destination statements with
+	 * {@link Statement#isEqualTo(Statement)} instead of using
+	 * {@link Statement#equals(Object)}
+	 * 
+	 * @param other the other edge
+	 * @return {@code true} if this edge and the given one are effectively equals
+	 */
+	public boolean isEqualTo(Edge other) {
+		if (this == other)
+			return true;
+		if (other == null)
+			return false;
+		if (getClass() != other.getClass())
+			return false;
+		if (destination == null) {
+			if (other.destination != null)
+				return false;
+		} else if (!destination.isEqualTo(other.destination))
+			return false;
+		if (source == null) {
+			if (other.source != null)
+				return false;
+		} else if (!source.isEqualTo(other.source))
+			return false;
+		return true;
 	}
+
+	@Override
+	public abstract String toString();
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/edge/FalseEdge.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/edge/FalseEdge.java
@@ -1,15 +1,15 @@
-package it.unive.lisa.cfg;
+package it.unive.lisa.cfg.edge;
 
 import it.unive.lisa.cfg.statement.Statement;
 
 /**
  * A sequential edge connecting two statements. The abstract analysis state
  * gets modified by assuming that the statement where this edge originates does
- * hold.
+ * not hold.
  * 
  * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
  */
-public class TrueEdge extends Edge {
+public class FalseEdge extends Edge {
 
 	/**
 	 * Builds the edge.
@@ -17,7 +17,12 @@ public class TrueEdge extends Edge {
 	 * @param source      the source statement
 	 * @param destination the destination statement
 	 */
-	public TrueEdge(Statement source, Statement destination) {
+	public FalseEdge(Statement source, Statement destination) {
 		super(source, destination);
+	}
+	
+	@Override
+	public String toString() {
+		return "[ " + getSource() + " ] -F-> [ " + getDestination() + " ]";
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/edge/SequentialEdge.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/edge/SequentialEdge.java
@@ -1,4 +1,4 @@
-package it.unive.lisa.cfg;
+package it.unive.lisa.cfg.edge;
 
 import it.unive.lisa.cfg.statement.Statement;
 
@@ -18,5 +18,10 @@ public class SequentialEdge extends Edge {
 	 */
 	public SequentialEdge(Statement source, Statement destination) {
 		super(source, destination);
+	}
+	
+	@Override
+	public String toString() {
+		return "[ " + getSource() + " ] ---> [ " + getDestination() + " ]";
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/edge/TrueEdge.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/edge/TrueEdge.java
@@ -1,15 +1,15 @@
-package it.unive.lisa.cfg;
+package it.unive.lisa.cfg.edge;
 
 import it.unive.lisa.cfg.statement.Statement;
 
 /**
  * A sequential edge connecting two statements. The abstract analysis state
  * gets modified by assuming that the statement where this edge originates does
- * not hold.
+ * hold.
  * 
  * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
  */
-public class FalseEdge extends Edge {
+public class TrueEdge extends Edge {
 
 	/**
 	 * Builds the edge.
@@ -17,7 +17,12 @@ public class FalseEdge extends Edge {
 	 * @param source      the source statement
 	 * @param destination the destination statement
 	 */
-	public FalseEdge(Statement source, Statement destination) {
+	public TrueEdge(Statement source, Statement destination) {
 		super(source, destination);
+	}
+	
+	@Override
+	public String toString() {
+		return "[ " + getSource() + " ] -T-> [ " + getDestination() + " ]";
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/NoOp.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/NoOp.java
@@ -1,0 +1,60 @@
+package it.unive.lisa.cfg.statement;
+
+import it.unive.lisa.cfg.CFG;
+
+/**
+ * A statement that does nothing. Can be used for instrumenting branching
+ * operations.
+ * 
+ * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
+ */
+public class NoOp extends Statement {
+
+	/**
+	 * Builds the no-op. The location where this no-op happens is unknown (i.e. no
+	 * source file/line/column is available).
+	 * 
+	 * @param cfg the cfg that this statement belongs to
+	 */
+	public NoOp(CFG cfg) {
+		this(cfg, null, -1, -1);
+	}
+
+	/**
+	 * Builds the no-op, happening at the given
+	 * location in the program.
+	 * 
+	 * @param cfg        the cfg that this statement belongs to
+	 * @param sourceFile the source file where this statement happens. If unknown,
+	 *                   use {@code null}
+	 * @param line       the line number where this statement happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param col        the column where this statement happens in the source file.
+	 *                   If unknown, use {@code -1}
+	 */
+	public NoOp(CFG cfg, String sourceFile, int line, int col) {
+		super(cfg, sourceFile, line, col);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + getClass().getName().hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean isEqualTo(Statement st) {
+		if (this == st)
+			return true;
+		if (getClass() != st.getClass())
+			return false;
+		return true;
+	}
+
+	@Override
+	public final String toString() {
+		return "no-op";
+	}
+}

--- a/lisa/src/main/java/it/unive/lisa/util/collections/ExternalSet.java
+++ b/lisa/src/main/java/it/unive/lisa/util/collections/ExternalSet.java
@@ -1,0 +1,568 @@
+package it.unive.lisa.util.collections;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A set of elements that are stored externally from this set. Elements are
+ * stored inside an {@link ExternalSetCache} instance that is shared among all
+ * the sets created from that instance. This avoid the duplication of the
+ * references to the elements, enabling this class' instances to store the
+ * indexes of the elements inside the cache instead of the full memory address.
+ * The indexes are stored through bit vectors, enabling better memory
+ * efficiency.
+ * 
+ * @param <T> the type of elements inside this set
+ * 
+ * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
+ */
+public class ExternalSet<T> implements Iterable<T> {
+
+	private static final int LENGTH_MASK = 0x3f;
+
+	/**
+	 * Yields a mask of {@code 0}s with one 1, represented as a long value, to
+	 * represent the given number inside a long bitvector. To determine the correct
+	 * long bitvector to apply this mask to, use {@link #bitvector_index(int)}
+	 * 
+	 * @param n the number
+	 * @return the bitwise mask
+	 */
+	private static long bitmask(int n) {
+		// assuming that n will be stored in the right long (obtained with toNLongs(n)),
+		// we have to determine which bit of the long has to be turned to 1. To do that,
+		// we take the 1L (that is just the right-most bit set to 1) and we shift it to
+		// the left. The amount of positions that we need to shift it is equal to n%64
+		// (we use bitwise and as a mask) that yields the correct bit to represent a
+		// number between 0 and 63 inside the long
+		return 1L << (n & LENGTH_MASK);
+	}
+
+	/**
+	 * Yields the 0-based index of the bitvector where the bit representing the
+	 * given number lies.
+	 * 
+	 * @param n the number
+	 * @return the index
+	 */
+	private static int bitvector_index(int n) {
+		// a long is 64 (2^6) bits, and can thus represent 64 elements.
+		// shifting n to the right by 6 determines the number of
+		// 64-bits chunks needed to represent that number.
+		return n >> 6;
+	}
+
+	private static void set(long[] bits, int n) {
+		bits[bitvector_index(n)] |= bitmask(n);
+	}
+
+	private static void unset(long[] bits, int n) {
+		bits[bitvector_index(n)] &= ~bitmask(n);
+	}
+
+	private static boolean isset(long bitvector, int pos) {
+		return (bitvector & bitmask(pos)) != 0L;
+	}
+
+	/**
+	 * The bits representing the set. If a bit is 1 then the corresponding element
+	 * of the cache is in the set.
+	 */
+	private long[] bits;
+
+	/**
+	 * The cache that generated this set and that contains the elements of this set.
+	 */
+	private final ExternalSetCache<T> cache;
+
+	/**
+	 * Builds an empty set connected to the given cache.
+	 * 
+	 * @param cache the cache
+	 */
+	protected ExternalSet(ExternalSetCache<T> cache) {
+		this.bits = new long[1];
+		this.cache = cache;
+	}
+
+	/**
+	 * Builds a set with the given bits and cache.
+	 * 
+	 * @param bits  the bits
+	 * @param cache the cache
+	 */
+	protected ExternalSet(long[] bits, ExternalSetCache<T> cache) {
+		this.bits = bits;
+		this.cache = cache;
+	}
+
+	/**
+	 * Builds a clone of another set, connected to the same cache.
+	 * 
+	 * @param other the other set
+	 */
+	protected ExternalSet(ExternalSet<T> other) {
+		this.bits = other.bits.clone();
+		this.cache = other.cache;
+	}
+
+	/**
+	 * Builds a set containing exactly one element and connected to the given cache.
+	 * 
+	 * @param cache   the cache
+	 * @param element the element
+	 */
+	protected ExternalSet(ExternalSetCache<T> cache, T element) {
+		this.cache = cache;
+		int pos = cache.indexOfOrAdd(element);
+		bits = new long[1 + bitvector_index(pos)];
+		set(bits, pos);
+	}
+
+	/**
+	 * Builds a set containing all the elements of the given iterable and connected
+	 * to the given cache.
+	 * 
+	 * @param cache    the cache that must be used for this set
+	 * @param elements the elements put inside the set
+	 */
+	protected ExternalSet(ExternalSetCache<T> cache, Iterable<T> elements) {
+		this(cache);
+		for (T e : elements)
+			add(e);
+	}
+
+	/**
+	 * Yields the cache that this set is connected to.
+	 * 
+	 * @return the cache
+	 */
+	public ExternalSetCache<T> getCache() {
+		return cache;
+	}
+
+	/**
+	 * Adds the given element to this set.
+	 * 
+	 * @param e the element to add
+	 */
+	public void add(T e) {
+		long[] localbits = bits;
+		int pos = cache.indexOfOrAdd(e);
+		int bitvector = bitvector_index(pos);
+
+		if (bitvector >= localbits.length) {
+			// the array is not long enough for the position
+			// of the element that we are adding
+			bits = new long[1 + bitvector];
+			System.arraycopy(localbits, 0, bits, 0, localbits.length);
+			set(bits, pos);
+		} else
+			set(localbits, pos);
+	}
+
+	/**
+	 * Removes the given element from this set.
+	 * 
+	 * @param e the element to remove
+	 */
+	public void remove(T e) {
+		int pos = getCache().indexOf(e);
+		if (pos < 0)
+			return;
+
+		long[] localbits = this.bits;
+		if (bitvector_index(pos) >= localbits.length)
+			return;
+
+		unset(localbits, pos);
+		removeTrailingZeros();
+	}
+
+	/**
+	 * Yields the number of elements in this set.
+	 * 
+	 * @return the number of elements in this set
+	 */
+	public int size() {
+		long bitvector;
+		int count = 0;
+		long[] localbits = this.bits;
+
+		for (int pos = localbits.length - 1; pos >= 0; pos--) {
+			bitvector = localbits[pos];
+			if (bitvector != 0L)
+				for (int i = 0; i < 64; i++)
+					// we iterate over all possible bits of the bitvector
+					if (isset(bitvector, i))
+						count++;
+		}
+
+		return count;
+	}
+
+	/**
+	 * Determines if this set is empty.
+	 * 
+	 * @return true if and only if this set is empty
+	 */
+	public final boolean isEmpty() {
+		removeTrailingZeros();
+		return bits.length == 1 && bits[0] == 0L;
+	}
+
+	private void removeTrailingZeros() {
+		long[] localbits = bits;
+		int length = localbits.length;
+
+		// we search for the right-most bitvector that has at least one
+		// bit set to 1, excluding the first one since if even if it is
+		// zero we have to leave it as it is (at least one bitvector is needed)
+		while (length > 1 && localbits[length - 1] == 0L)
+			length--;
+
+		if (length != localbits.length) {
+			// if we decreased at least once, we can shrink the bits
+			bits = new long[length];
+			System.arraycopy(localbits, 0, bits, 0, length);
+		}
+	}
+
+	@Override
+	public final Iterator<T> iterator() {
+		return new BitSetIterator();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(bits);
+		return result;
+	}
+
+	/**
+	 * Determines if this set is equal to the given one, that is, if they share the
+	 * cache (checked through reference equality) and contains the same elements.
+	 * <br>
+	 * <br>
+	 * {@inheritDoc}
+	 */
+	@Override
+	public final boolean equals(Object obj) {
+		if (obj == null)
+			return false;
+		if (this == obj)
+			return true;
+		if (obj.getClass() != getClass())
+			return false;
+		ExternalSet<?> other = (ExternalSet<?>) obj;
+		if (cache != other.cache)
+			return false;
+		if (!Arrays.equals(bits, other.bits))
+			return false;
+		return true;
+	}
+
+	@Override
+	public final String toString() {
+		return "[" + StringUtils.join(this, ", ") + "]";
+	}
+
+	/**
+	 * Removes all elements from this set.
+	 */
+	public void clear() {
+		this.bits = new long[1];
+	}
+
+	/**
+	 * Yields a concrete list containing all the elements corresponding to the bits
+	 * in this set.
+	 * 
+	 * @return the collected elements
+	 */
+	public List<T> collect() {
+		List<T> list = new ArrayList<>();
+		for (T e : this)
+			list.add(e);
+		return list;
+	}
+
+	/**
+	 * Yields a fresh copy of this set, defined over the same cache and containing
+	 * the same elements.
+	 * 
+	 * @return the fresh copy
+	 */
+	public ExternalSet<T> copy() {
+		return new ExternalSet<>(this);
+	}
+
+	/**
+	 * Determines if an element belongs to this set.
+	 * 
+	 * @param e the element
+	 * @return true if and only if {@code e} is in this set
+	 */
+	public final boolean contains(T e) {
+		int pos = cache.indexOf(e);
+		if (pos < 0)
+			// if it's not inside the cache, it's not in the set
+			return false;
+
+		int bitvector = bitvector_index(pos);
+		return bitvector < bits.length && isset(bits[bitvector], pos);
+	}
+
+	/**
+	 * Determines if this set contains all elements of another if they share the
+	 * same cache.
+	 * 
+	 * @param other the other set
+	 * @return {@code true} if and only if {@code other} is included into this set
+	 */
+	public boolean contains(ExternalSet<T> other) {
+		if (this == other)
+			return true;
+		if (other == null)
+			return false;
+		if (cache != other.cache)
+			return false;
+
+		long[] otherbits = other.bits, localbits = bits;
+		if (otherbits.length > localbits.length)
+			// clever check: this cannot contain other if other is bigger
+			return false;
+
+		// if at least one bit that is 0 in this is 1 in other, than this does not
+		// contain other
+		for (int i = otherbits.length; i >= 0; i--)
+			if ((localbits[i] | otherbits[i]) != localbits[i])
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Determines if this set has at least an element in common with another if they
+	 * share the same cache.
+	 * 
+	 * @param other the other set
+	 * @return true if and only if this set intersects the other
+	 */
+	public final boolean intersects(ExternalSet<T> other) {
+		if (this == other)
+			return true;
+		if (other == null)
+			return false;
+		if (cache != other.cache)
+			return false;
+
+		// if at least one bit is one on both, then the two intersect
+		long[] otherbits = other.bits, localbits = bits;
+		int min = (otherbits.length > localbits.length) ? localbits.length : otherbits.length;
+		for (int i = min - 1; i >= 0; i--)
+			if ((localbits[i] & otherbits[i]) != 0L)
+				return true;
+
+		return false;
+	}
+
+	/**
+	 * Yields the intersection of this set and another. Neither of them gets
+	 * modified. If {@code other} is {@code null}, or if the two sets are not
+	 * defined over the same cache, this set is returned.
+	 * 
+	 * @param other the other set
+	 * @return the intersection of the two sets
+	 */
+	public ExternalSet<T> intersection(ExternalSet<T> other) {
+		if (this == other)
+			return this;
+		if (other == null)
+			return this;
+		if (cache != other.cache)
+			return this;
+
+		int index;
+		long[] otherbits;
+		ExternalSet<T> result;
+
+		// copy the shortest one, then perform bitwise and with the longest one on
+		// common bits
+		if (this.bits.length > other.bits.length) {
+			otherbits = this.bits;
+			index = other.bits.length;
+			result = new ExternalSet<>(other);
+		} else {
+			otherbits = other.bits;
+			index = bits.length;
+			result = new ExternalSet<>(this);
+		}
+
+		long[] res = result.bits;
+		while (index > 0)
+			res[--index] &= otherbits[index];
+		result.removeTrailingZeros();
+		return result;
+	}
+
+	/**
+	 * Yields a new set obtained from this by removing the given elements. If
+	 * {@code other} is {@code null}, or if the two sets are not defined over the
+	 * same cache, this set is returned.
+	 * 
+	 * @param other the elements to remove
+	 * @return a set obtained from this by removing the elements in {@code other}
+	 */
+	public ExternalSet<T> difference(ExternalSet<T> other) {
+		if (this == other)
+			return this;
+		if (other == null)
+			return this;
+		if (cache != other.cache)
+			return this;
+
+		long[] localbits = this.bits;
+		int pos = localbits.length;
+		ExternalSet<T> result = new ExternalSet<>(this);
+		long[] otherbits = other.bits, res = result.bits;
+
+		if (otherbits.length < pos)
+			pos = otherbits.length;
+
+		while (--pos >= 0)
+			res[pos] &= ~otherbits[pos];
+
+		result.removeTrailingZeros();
+		return result;
+	}
+
+	/**
+	 * Yields the union of this set and another. Neither of them gets modified. If
+	 * {@code other} is {@code null}, or if the two sets are not defined over the
+	 * same cache, this set is returned.
+	 * 
+	 * @param other the other set
+	 * @return the union of this set and {@code other}
+	 */
+	public ExternalSet<T> union(ExternalSet<T> other) {
+		if (this == other)
+			return this;
+		if (other == null)
+			return this;
+		if (cache != other.cache)
+			return this;
+
+		long[] localbits = this.bits, otherbits = other.bits;
+		int thislength = localbits.length, otherlength = otherbits.length;
+		ExternalSet<T> result;
+
+		if (thislength < otherlength) {
+			result = new ExternalSet<>(other);
+			long[] res = result.bits;
+			for (--thislength; thislength >= 0; thislength--)
+				res[thislength] |= localbits[thislength];
+		} else {
+			result = new ExternalSet<>(this);
+			long[] res = result.bits;
+			while (--otherlength >= 0)
+				res[otherlength] |= otherbits[otherlength];
+		}
+
+		return result;
+	}
+
+	/**
+	 * An iterator over the elements of a {@link ExternalSet}.
+	 * 
+	 * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
+	 */
+	private class BitSetIterator implements Iterator<T> {
+
+		/**
+		 * The next bit to look at
+		 */
+		private int next;
+
+		/**
+		 * The bits to iterate over
+		 */
+		private final long[] bits;
+
+		/**
+		 * The total number of bits to iterate over
+		 */
+		private final int totalBits;
+
+		/**
+		 * Builds an iterator from the given bits and elements.
+		 */
+		private BitSetIterator() {
+			this.bits = ExternalSet.this.bits;
+			this.totalBits = bits.length << 6; // we go back to the integer representation
+			this.next = findNextBit();
+		}
+
+		/**
+		 * Yields the next non-ZERO bit in the set.
+		 * 
+		 * @return the position of the next non-zero bit in the set, starting at
+		 *         {@code start} non-inclusive, or {@code -1}
+		 */
+		private int findNextBit() {
+			long[] localbits = this.bits;
+			int start = next;
+			int l = this.totalBits;
+
+			while (start < l) {
+				int pos = bitvector_index(start);
+				long bitvector = localbits[pos];
+
+				while (bitvector == 0L) {
+					// we can skip to the next vector
+					if ((start += 64) >= l)
+						return -1;
+					bitvector = localbits[++pos];
+				}
+
+				long bit = bitmask(start);
+				do {
+					if ((bitvector & bit) != 0L)
+						return start;
+
+					bit <<= 1;
+					start++;
+				} while (bit != 0);
+			}
+
+			return -1;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return next >= 0;
+		}
+
+		@Override
+		public T next() {
+			int nb = next++;
+			next = findNextBit();
+
+			return cache.get(nb);
+		}
+
+		/**
+		 * Removal is not supported!
+		 */
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException("Removal from a bitset is not supported");
+		}
+	}
+}

--- a/lisa/src/main/java/it/unive/lisa/util/collections/ExternalSetCache.java
+++ b/lisa/src/main/java/it/unive/lisa/util/collections/ExternalSetCache.java
@@ -1,0 +1,135 @@
+package it.unive.lisa.util.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A cache for creating {@link ExternalSet}s of the elements contained in this
+ * cache.
+ * 
+ * @param <T> the type of elements that this cache stores
+ * 
+ * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
+ */
+public class ExternalSetCache<T> {
+
+	/**
+	 * The collection of elements in this cache
+	 */
+	private final List<T> elements = new ArrayList<>(16);
+
+	/**
+	 * A map from the elements to their index
+	 */
+	private final ConcurrentMap<T, Integer> indexes = new ConcurrentHashMap<>(16);
+
+	/**
+	 * The next index available for new elements
+	 */
+	private int nextIndex;
+
+	/**
+	 * The index assigned to the {@code null} key, if any.
+	 */
+	private int indexOfNull = -1;
+
+	/**
+	 * Builds an empty {@link ExternalSet} that uses this cache.
+	 * 
+	 * @return the empty set
+	 */
+	public ExternalSet<T> mkEmptySet() {
+		return new ExternalSet<T>(this);
+	}
+
+	/**
+	 * Builds an {@link ExternalSet} that uses this cache and contains the elements
+	 * of the given iterable.
+	 *
+	 * @param iterable the iterable
+	 * @return the set
+	 */
+	public ExternalSet<T> mkSet(Iterable<T> iterable) {
+		return new ExternalSet<T>(this, iterable);
+	}
+
+	/**
+	 * Builds an {@link ExternalSet} that uses this cache and contains only the
+	 * given element.
+	 * 
+	 * @param element the element
+	 * @return the set
+	 */
+	public ExternalSet<T> mkSingletonSet(T element) {
+		return new ExternalSet<T>(this, element);
+	}
+
+	/**
+	 * Yields the index where the given element is stored in this cache.
+	 * 
+	 * @param e the element
+	 * @return the index of {@code e}, or {@code -1}
+	 */
+	protected final int indexOf(T e) {
+		if (e == null)
+			return indexOfNull;
+
+		Integer result;
+		return (result = indexes.get(e)) == null ? -1 : result;
+	}
+
+	/**
+	 * Yields the index where the given element is stored in this cache. If the
+	 * element is not currently in this cache, it is added.
+	 * 
+	 * @param e the element
+	 * @return the index of {@code e}
+	 */
+	protected final int indexOfOrAdd(T e) {
+		if (e == null)
+			synchronized (this) {
+				if (indexOfNull == -1) {
+					elements.add(null);
+					indexOfNull = nextIndex++;
+				}
+				return indexOfNull;
+			}
+
+		Integer result = indexes.get(e);
+		if (result == null)
+			synchronized (this) {
+				return indexes.computeIfAbsent(e, el -> {
+					elements.add(e);
+					return nextIndex++;
+				});
+			}
+
+		return result;
+	}
+
+	/**
+	 * Yields the {@code pos}-th element of this cache.
+	 *
+	 * @param pos the position
+	 * @return the element 
+	 */
+	protected final synchronized T get(int pos) {
+		return elements.get(pos);
+	}
+
+	/**
+	 * Yields the total number of elements stored in this cache.
+	 * 
+	 * @return the number of elements
+	 */
+	public final synchronized int size() {
+		return elements.size();
+	}
+
+	@Override
+	public final synchronized String toString() {
+		return elements.toString();
+	}
+}

--- a/lisa/src/test/java/it/unive/lisa/test/cfg/CFGSimplificationTest.java
+++ b/lisa/src/test/java/it/unive/lisa/test/cfg/CFGSimplificationTest.java
@@ -1,0 +1,156 @@
+package it.unive.lisa.test.cfg;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.CFGDescriptor;
+import it.unive.lisa.cfg.edge.FalseEdge;
+import it.unive.lisa.cfg.edge.SequentialEdge;
+import it.unive.lisa.cfg.edge.TrueEdge;
+import it.unive.lisa.cfg.statement.Assignment;
+import it.unive.lisa.cfg.statement.Expression;
+import it.unive.lisa.cfg.statement.Literal;
+import it.unive.lisa.cfg.statement.NativeCall;
+import it.unive.lisa.cfg.statement.NoOp;
+import it.unive.lisa.cfg.statement.Return;
+import it.unive.lisa.cfg.statement.Variable;
+
+public class CFGSimplificationTest {
+
+	@Test
+	public void testSimpleSimplification() {
+		CFG first = new CFG(new CFGDescriptor("foo"));
+		Assignment assign = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+		NoOp noop = new NoOp(first);
+		Return ret = new Return(first, new Variable(first, "x"));
+		first.addNode(assign, true);
+		first.addNode(noop);
+		first.addNode(ret);
+		first.addEdge(new SequentialEdge(assign, noop));
+		first.addEdge(new SequentialEdge(noop, ret));
+		
+		
+		CFG second = new CFG(new CFGDescriptor("foo"));
+		assign = new Assignment(second, new Variable(second, "x"), new Literal(second, 5));
+		ret = new Return(second, new Variable(second, "x"));
+
+		second.addNode(assign, true);
+		second.addNode(ret);
+		
+		second.addEdge(new SequentialEdge(assign, ret));
+
+		first.simplify();
+		assertTrue("Different CFGs", second.isEqualTo(first));
+	}
+	
+	@Test
+	public void testDoubleSimplification() {
+		CFG first = new CFG(new CFGDescriptor("foo"));
+		Assignment assign = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+		NoOp noop1 = new NoOp(first);
+		NoOp noop2 = new NoOp(first);
+		Return ret = new Return(first, new Variable(first, "x"));
+		first.addNode(assign, true);
+		first.addNode(noop1);
+		first.addNode(noop2);
+		first.addNode(ret);
+		first.addEdge(new SequentialEdge(assign, noop1));
+		first.addEdge(new SequentialEdge(noop1, noop2));
+		first.addEdge(new SequentialEdge(noop2, ret));
+		
+		
+		CFG second = new CFG(new CFGDescriptor("foo"));
+		assign = new Assignment(second, new Variable(second, "x"), new Literal(second, 5));
+		ret = new Return(second, new Variable(second, "x"));
+
+		second.addNode(assign, true);
+		second.addNode(ret);
+		
+		second.addEdge(new SequentialEdge(assign, ret));
+
+		first.simplify();
+		assertTrue("Different CFGs", second.isEqualTo(first));
+	}
+	
+	@Test
+	public void testConditionalSimplification() {
+		class GT extends NativeCall {
+			protected GT(CFG cfg, Expression left, Expression right) {
+				super(cfg, "gt", left, right);
+			}
+		}
+		
+		class Print extends NativeCall {
+			protected Print(CFG cfg, Expression arg) {
+				super(cfg, "print", arg);
+			}
+		}
+		
+		CFG first = new CFG(new CFGDescriptor("foo"));
+		Assignment assign = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+		GT gt = new GT(first, new Variable(first, "x"), new Literal(first, 2)); 
+		Print print = new Print(first, new Literal(first, "f")); 
+		NoOp noop1 = new NoOp(first);
+		NoOp noop2 = new NoOp(first);
+		Return ret = new Return(first, new Variable(first, "x"));
+		first.addNode(assign, true);
+		first.addNode(gt);
+		first.addNode(print);
+		first.addNode(noop1);
+		first.addNode(noop2);
+		first.addNode(ret);
+		first.addEdge(new SequentialEdge(assign, gt));
+		first.addEdge(new TrueEdge(gt, print));
+		first.addEdge(new FalseEdge(gt, noop1));
+		first.addEdge(new SequentialEdge(noop1, noop2));
+		first.addEdge(new SequentialEdge(print, noop2));
+		first.addEdge(new SequentialEdge(noop2, ret));
+		
+		
+		CFG second = new CFG(new CFGDescriptor("foo"));
+		assign = new Assignment(second, new Variable(second, "x"), new Literal(second, 5));
+		gt = new GT(second, new Variable(second, "x"), new Literal(second, 2)); 
+		print = new Print(second, new Literal(second, "f")); 
+		ret = new Return(second, new Variable(second, "x"));
+
+		second.addNode(assign, true);
+		second.addNode(gt);
+		second.addNode(print);
+		second.addNode(ret);
+		
+		second.addEdge(new SequentialEdge(assign, gt));
+		second.addEdge(new TrueEdge(gt, print));
+		second.addEdge(new FalseEdge(gt, ret));
+		second.addEdge(new SequentialEdge(print, ret));
+
+		first.simplify();
+		assertTrue("Different CFGs", second.isEqualTo(first));
+	}
+	
+	@Test
+	public void testSimplificationWithDuplicateStatements() {
+		CFG first = new CFG(new CFGDescriptor("foo"));
+		Assignment assign = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+		NoOp noop = new NoOp(first);
+		Assignment ret = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+		first.addNode(assign);
+		first.addNode(noop);
+		first.addNode(ret);
+		first.addEdge(new SequentialEdge(assign, noop));
+		first.addEdge(new SequentialEdge(noop, ret));
+		
+		CFG second = new CFG(new CFGDescriptor("foo"));
+		assign = new Assignment(second, new Variable(second, "x"), new Literal(second, 5));
+		ret = new Assignment(first, new Variable(first, "x"), new Literal(first, 5));
+
+		second.addNode(assign);
+		second.addNode(ret);
+		
+		second.addEdge(new SequentialEdge(assign, ret));
+
+		first.simplify();
+		assertTrue("Different CFGs", second.isEqualTo(first));
+	}
+}

--- a/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
+++ b/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
@@ -1,4 +1,4 @@
-package it.unive.lisa.test;
+package it.unive.lisa.test.checks.syntactic;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
**Description**
* Introduction of the NoOp statement for easing the instrumentation of some branching structures. NoOps can be then automatically removed by calling CFG#simplify()
* AdjacencyMatrix is now a map containing external cached sets for better efficiency. This also allows content-equality checks for the whole CFG.
