### PR TITLE
Added static typing information to LiSA

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -41,9 +41,9 @@ public class CFGDescriptor {
 	private final String name;
 
 	/**
-	 * The names of the arguments of the CFG associated with this descriptor.
+	 * The arguments of the CFG associated with this descriptor.
 	 */
-	private final Variable[] argNames;
+	private final Variable[] args;
 
 	/**
 	 * The return type of the CFG associated with this descriptor.
@@ -52,14 +52,26 @@ public class CFGDescriptor {
 	
 	/**
 	 * Builds the descriptor for a method that is defined at an unknown location
-	 * (i.e. no source file/line/column is available) and with untyped return type.
+	 * (i.e. no source file/line/column is available) and with untyped return type,
+	 * that is its type is {@link Untyped#INSTANCE}.
 	 * 
 	 * @param name     the name of the CFG associated with this descriptor
-	 * @param argNames the names of the arguments of the CFG associated with this
-	 *                 descriptor
+	 * @param args 	   the arguments of the CFG associated with this descriptor
 	 */
-	public CFGDescriptor(String name, Variable... argNames) {
-		this(null, -1, -1, name, Untyped.INSTANCE, argNames);
+	public CFGDescriptor(String name, Variable... args) {
+		this(null, -1, -1, name, Untyped.INSTANCE, args);
+	}
+	
+	/**
+	 * Builds the descriptor for a method that is defined at an unknown location
+	 * (i.e. no source file/line/column is available).
+	 * 
+	 * @param name		 the name of the CFG associated with this descriptor
+	 * @param returnType the return type of the CFG associated with this descriptor
+	 * @param args 	   	 the arguments of the CFG associated with this descriptor
+	 */
+	public CFGDescriptor(String name, Type returnType, Variable... args) {
+		this(null, -1, -1, name, returnType, args);
 	}
 
 	/**
@@ -74,20 +86,19 @@ public class CFGDescriptor {
 	 *                   defined in the source file. If unknown, use {@code -1}
 	 * @param name       the name of the CFG associated with this descriptor
 	 * @param returnType the return type of the CFG associated with this descriptor
-	 * @param argNames   the names of the arguments of the CFG associated with this
-	 *                   descriptor                
+	 * @param args   	 the arguments of the CFG associated with this descriptor                
 	 */
-	public CFGDescriptor(String sourceFile, int line, int col, String name, Type returnType, Variable... argNames) {
+	public CFGDescriptor(String sourceFile, int line, int col, String name, Type returnType, Variable... args) {
 		Objects.requireNonNull(name, "The name of a CFG cannot be null");
-		Objects.requireNonNull(argNames, "The array of argument names of a CFG cannot be null");
+		Objects.requireNonNull(args, "The array of argument names of a CFG cannot be null");
 		Objects.requireNonNull(returnType, "The return type of a CFG cannot be null");
-		for (int i = 0; i < argNames.length; i++)
-			Objects.requireNonNull(argNames[i], "The " + i + "-th argument name of a CFG cannot be null");
+		for (int i = 0; i < args.length; i++)
+			Objects.requireNonNull(args[i], "The " + i + "-th argument name of a CFG cannot be null");
 		this.sourceFile = sourceFile;
 		this.line = line;
 		this.col = col;
 		this.name = name;
-		this.argNames = argNames;
+		this.args = args;
 		this.returnType = returnType;
 	}
 
@@ -149,7 +160,7 @@ public class CFGDescriptor {
 	 * @return the signature
 	 */
 	public String getFullSignature() {
-		return name + "(" + StringUtils.join(argNames, ", ") + ")";
+		return name + "(" + StringUtils.join(args, ", ") + ")";
 	}
 
 	/**
@@ -158,8 +169,8 @@ public class CFGDescriptor {
 	 * 
 	 * @return the arguments names
 	 */
-	public Variable[] getArgNames() {
-		return argNames;
+	public Variable[] getArgs() {
+		return args;
 	}
 	
 	/**
@@ -175,7 +186,7 @@ public class CFGDescriptor {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + Arrays.hashCode(argNames);
+		result = prime * result + Arrays.hashCode(args);
 		result = prime * result + col;
 		result = prime * result + line;
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
@@ -193,7 +204,7 @@ public class CFGDescriptor {
 		if (getClass() != obj.getClass())
 			return false;
 		CFGDescriptor other = (CFGDescriptor) obj;
-		if (!Arrays.equals(argNames, other.argNames))
+		if (!Arrays.equals(args, other.args))
 			return false;
 		if (col != other.col)
 			return false;

--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
-import it.unive.lisa.cfg.statement.Variable;
+import it.unive.lisa.cfg.statement.Parameter;
 import it.unive.lisa.cfg.type.Type;
 import it.unive.lisa.cfg.type.Untyped;
 
@@ -43,13 +43,13 @@ public class CFGDescriptor {
 	/**
 	 * The arguments of the CFG associated with this descriptor.
 	 */
-	private final Variable[] args;
+	private final Parameter[] args;
 
 	/**
 	 * The return type of the CFG associated with this descriptor.
 	 */
 	private final Type returnType;
-	
+
 	/**
 	 * Builds the descriptor for a method that is defined at an unknown location
 	 * (i.e. no source file/line/column is available) and with untyped return type,
@@ -58,10 +58,10 @@ public class CFGDescriptor {
 	 * @param name     the name of the CFG associated with this descriptor
 	 * @param args 	   the arguments of the CFG associated with this descriptor
 	 */
-	public CFGDescriptor(String name, Variable... args) {
+	public CFGDescriptor(String name, Parameter... args) {
 		this(null, -1, -1, name, Untyped.INSTANCE, args);
 	}
-	
+
 	/**
 	 * Builds the descriptor for a method that is defined at an unknown location
 	 * (i.e. no source file/line/column is available).
@@ -70,7 +70,7 @@ public class CFGDescriptor {
 	 * @param returnType the return type of the CFG associated with this descriptor
 	 * @param args 	   	 the arguments of the CFG associated with this descriptor
 	 */
-	public CFGDescriptor(String name, Type returnType, Variable... args) {
+	public CFGDescriptor(String name, Type returnType, Parameter... args) {
 		this(null, -1, -1, name, returnType, args);
 	}
 
@@ -88,7 +88,7 @@ public class CFGDescriptor {
 	 * @param returnType the return type of the CFG associated with this descriptor
 	 * @param args   	 the arguments of the CFG associated with this descriptor                
 	 */
-	public CFGDescriptor(String sourceFile, int line, int col, String name, Type returnType, Variable... args) {
+	public CFGDescriptor(String sourceFile, int line, int col, String name, Type returnType, Parameter... args) {
 		Objects.requireNonNull(name, "The name of a CFG cannot be null");
 		Objects.requireNonNull(args, "The array of argument names of a CFG cannot be null");
 		Objects.requireNonNull(returnType, "The return type of a CFG cannot be null");
@@ -157,22 +157,22 @@ public class CFGDescriptor {
 	/**
 	 * Yields the full signature of this cfg.
 	 * 
-	 * @return the signature
+	 * @return the full signature 
 	 */
 	public String getFullSignature() {
-		return returnType + " " + name + "(" + StringUtils.join(args, ", ") + ")";
+		return returnType + " " + name + "(" + StringUtils.join(args, ", ")+ ")";
 	}
 
 	/**
-	 * Yields the array containing the names of the arguments of the CFG associated
+	 * Yields the array containing the arguments of the CFG associated
 	 * with this descriptor.
 	 * 
-	 * @return the arguments names
+	 * @return the arguments
 	 */
-	public Variable[] getArgs() {
+	public Parameter[] getArgs() {
 		return args;
 	}
-	
+
 	/**
 	 * Yields the return type of the CFG associated with this descriptor.
 	 * 

--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -180,6 +180,7 @@ public class CFGDescriptor {
 		result = prime * result + line;
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + ((sourceFile == null) ? 0 : sourceFile.hashCode());
+		result = prime * result + ((returnType == null) ? 0 : returnType.hashCode());
 		return result;
 	}
 

--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -5,6 +5,10 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
+import it.unive.lisa.cfg.statement.Variable;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
+
 /**
  * A descriptor of a CFG, containing the debug informations (source file, line,
  * column) as well as metadata
@@ -39,18 +43,23 @@ public class CFGDescriptor {
 	/**
 	 * The names of the arguments of the CFG associated with this descriptor.
 	 */
-	private final String[] argNames;
+	private final Variable[] argNames;
 
 	/**
+	 * The return type of the CFG associated with this descriptor.
+	 */
+	private final Type returnType;
+	
+	/**
 	 * Builds the descriptor for a method that is defined at an unknown location
-	 * (i.e. no source file/line/column is available).
+	 * (i.e. no source file/line/column is available) and with untyped return type.
 	 * 
 	 * @param name     the name of the CFG associated with this descriptor
 	 * @param argNames the names of the arguments of the CFG associated with this
 	 *                 descriptor
 	 */
-	public CFGDescriptor(String name, String... argNames) {
-		this(null, -1, -1, name, argNames);
+	public CFGDescriptor(String name, Variable... argNames) {
+		this(null, -1, -1, name, Untyped.INSTANCE, argNames);
 	}
 
 	/**
@@ -64,12 +73,14 @@ public class CFGDescriptor {
 	 * @param col        the column where the CFG associated with this descriptor is
 	 *                   defined in the source file. If unknown, use {@code -1}
 	 * @param name       the name of the CFG associated with this descriptor
+	 * @param returnType the return type of the CFG associated with this descriptor
 	 * @param argNames   the names of the arguments of the CFG associated with this
-	 *                   descriptor
+	 *                   descriptor                
 	 */
-	public CFGDescriptor(String sourceFile, int line, int col, String name, String... argNames) {
+	public CFGDescriptor(String sourceFile, int line, int col, String name, Type returnType, Variable... argNames) {
 		Objects.requireNonNull(name, "The name of a CFG cannot be null");
 		Objects.requireNonNull(argNames, "The array of argument names of a CFG cannot be null");
+		Objects.requireNonNull(returnType, "The return type of a CFG cannot be null");
 		for (int i = 0; i < argNames.length; i++)
 			Objects.requireNonNull(argNames[i], "The " + i + "-th argument name of a CFG cannot be null");
 		this.sourceFile = sourceFile;
@@ -77,6 +88,7 @@ public class CFGDescriptor {
 		this.col = col;
 		this.name = name;
 		this.argNames = argNames;
+		this.returnType = returnType;
 	}
 
 	/**
@@ -146,8 +158,17 @@ public class CFGDescriptor {
 	 * 
 	 * @return the arguments names
 	 */
-	public String[] getArgNames() {
+	public Variable[] getArgNames() {
 		return argNames;
+	}
+	
+	/**
+	 * Yields the return type of the CFG associated with this descriptor.
+	 * 
+	 * @return the return type
+	 */
+	public Type getReturnType() {
+		return returnType;
 	}
 
 	@Override
@@ -186,6 +207,8 @@ public class CFGDescriptor {
 			if (other.sourceFile != null)
 				return false;
 		} else if (!sourceFile.equals(other.sourceFile))
+			return false;
+		if (!getReturnType().equals(other.getReturnType()))
 			return false;
 		return true;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -160,7 +160,7 @@ public class CFGDescriptor {
 	 * @return the signature
 	 */
 	public String getFullSignature() {
-		return name + "(" + StringUtils.join(args, ", ") + ")";
+		return returnType + " " + name + "(" + StringUtils.join(args, ", ") + ")";
 	}
 
 	/**

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
@@ -1,5 +1,7 @@
 package it.unive.lisa.cfg.statement;
 
+import java.util.Objects;
+
 import it.unive.lisa.cfg.CFG;
 import it.unive.lisa.cfg.type.Type;
 import it.unive.lisa.cfg.type.Untyped;
@@ -14,11 +16,11 @@ public abstract class Expression extends Statement {
 	/**
 	 * The static type of this expression
 	 */
-	private final Type type;
+	protected final Type type;
 	
 	/**
 	 * Builds an untyped expression happening at the given source location,
-	 * that is its type is Untyped.
+	 * that is its type is {@code Untyped.INSTANCE}.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -31,7 +33,7 @@ public abstract class Expression extends Statement {
 	protected Expression(CFG cfg, String sourceFile, int line, int col) {
 		this(cfg, sourceFile, line, col, Untyped.INSTANCE);
 	}
-	
+		
 	/**
 	 * Builds a typed expression happening at the given source location.
 	 * 
@@ -46,6 +48,7 @@ public abstract class Expression extends Statement {
 	 */
 	protected Expression(CFG cfg, String sourceFile, int line, int col, Type type) {
 		super(cfg, sourceFile, line, col);
+		Objects.requireNonNull(type, "The expression type of a CFG cannot be null");
 		this.type = type;
 	}
 	

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
@@ -16,11 +16,11 @@ public abstract class Expression extends Statement {
 	/**
 	 * The static type of this expression
 	 */
-	protected final Type type;
+	protected final Type staticType;
 	
 	/**
 	 * Builds an untyped expression happening at the given source location,
-	 * that is its type is {@code Untyped.INSTANCE}.
+	 * that is its type is {@link Untyped#INSTANCE}.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -44,20 +44,20 @@ public abstract class Expression extends Statement {
 	 *                   file. If unknown, use {@code -1}
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
-	 * @param type		 the type of this expression
+	 * @param staticType the static type of this expression
 	 */
-	protected Expression(CFG cfg, String sourceFile, int line, int col, Type type) {
+	protected Expression(CFG cfg, String sourceFile, int line, int col, Type staticType) {
 		super(cfg, sourceFile, line, col);
-		Objects.requireNonNull(type, "The expression type of a CFG cannot be null");
-		this.type = type;
+		Objects.requireNonNull(staticType, "The expression type of a CFG cannot be null");
+		this.staticType = staticType;
 	}
 	
 	/**
-	 * Yields the type of this expression.
+	 * Yields the static type of this expression.
 	 * 
-	 * @return the type of this expression
+	 * @return the static type of this expression
 	 */
-	public Type getType() {
-		return type;
+	public Type getStaticType() {
+		return staticType;
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Expression.java
@@ -1,6 +1,8 @@
 package it.unive.lisa.cfg.statement;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
 
 /**
  * An expression that is part of a statement of the program.
@@ -10,7 +12,13 @@ import it.unive.lisa.cfg.CFG;
 public abstract class Expression extends Statement {
 
 	/**
-	 * Builds an expression happening at the given source location.
+	 * The static type of this expression
+	 */
+	private final Type type;
+	
+	/**
+	 * Builds an untyped expression happening at the given source location,
+	 * that is its type is Untyped.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -21,6 +29,32 @@ public abstract class Expression extends Statement {
 	 *                   file. If unknown, use {@code -1}
 	 */
 	protected Expression(CFG cfg, String sourceFile, int line, int col) {
+		this(cfg, sourceFile, line, col, Untyped.INSTANCE);
+	}
+	
+	/**
+	 * Builds a typed expression happening at the given source location.
+	 * 
+	 * @param cfg        the cfg that this expression belongs to
+	 * @param sourceFile the source file where this expression happens. If unknown,
+	 *                   use {@code null}
+	 * @param line       the line number where this expression happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param col        the column where this expression happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param type		 the type of this expression
+	 */
+	protected Expression(CFG cfg, String sourceFile, int line, int col, Type type) {
 		super(cfg, sourceFile, line, col);
+		this.type = type;
+	}
+	
+	/**
+	 * Yields the type of this expression.
+	 * 
+	 * @return the type of this expression
+	 */
+	public Type getType() {
+		return type;
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
@@ -19,7 +19,7 @@ public class Literal extends Expression {
 	private final Object value;
 
 	/**
-	 * Builds the literal, consisting of a constant value. The location where this
+	 * Builds an untyped literal, consisting of a constant value. The location where this
 	 * literal happens is unknown (i.e. no source file/line/column is available).
 	 * The type of this literal is unknown (i.e. its type is {@link Untyped#INSTANCE}).
 	 * 
@@ -31,20 +31,21 @@ public class Literal extends Expression {
 	}
 	
 	/**
-	 * Builds the literal, consisting of a constant value. The location where this
+	 * Builds a typed literal, consisting of a constant value. The location where this
 	 * literal happens is unknown (i.e. no source file/line/column is available).
 	 * 
-	 * @param cfg   the cfg that this expression belongs to
-	 * @param value the value of this literal
-	 * @param type	the type of this literal
+	 * @param cfg   	 the cfg that this literal belongs to
+	 * @param value 	 the value of this literal
+	 * @param staticType the type of this literal
 	 */
-	public Literal(CFG cfg, Object value, Type type) {
-		this(cfg, null, -1, -1, value, type);
+	public Literal(CFG cfg, Object value, Type staticType) {
+		this(cfg, null, -1, -1, value, staticType);
 	}
 
 	/**
-	 * Builds the typed literal, consisting of a constant value, happening at the given
+	 * Builds the untyped literal, consisting of a constant value, happening at the given
 	 * location in the program.
+	 * The type of this literal is unknown (i.e. its type is {@link Untyped#INSTANCE}).
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -54,16 +55,13 @@ public class Literal extends Expression {
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
 	 * @param value      the value of this literal
-	 * @param type		 the type of this literal
 	 */
-	public Literal(CFG cfg, String sourceFile, int line, int col, Object value, Type type) {
-		super(cfg, sourceFile, line, col, type);
-		Objects.requireNonNull(value, "The value of a literal cannot be null");
-		this.value = value;
+	public Literal(CFG cfg, String sourceFile, int line, int col, Object value) {
+		this(cfg, sourceFile, line, col, value, Untyped.INSTANCE);
 	}
 	
 	/**
-	 * Builds the untyped literal, consisting of a constant value, happening at the given
+	 * Builds a typed literal, consisting of a constant value, happening at the given
 	 * location in the program.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
@@ -76,8 +74,8 @@ public class Literal extends Expression {
 	 * @param value      the value of this literal
 	 * @param staticType the type of this literal
 	 */
-	public Literal(CFG cfg, String sourceFile, int line, int col, Object value) {
-		super(cfg, sourceFile, line, col, Untyped.INSTANCE);
+	public Literal(CFG cfg, String sourceFile, int line, int col, Object value, Type staticType) {
+		super(cfg, sourceFile, line, col, staticType);
 		Objects.requireNonNull(value, "The value of a literal cannot be null");
 		this.value = value;
 	}
@@ -96,6 +94,7 @@ public class Literal extends Expression {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		result = prime * result + ((getStaticType() == null) ? 0 : getStaticType().hashCode());
 		return result;
 	}
 

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
@@ -3,6 +3,8 @@ package it.unive.lisa.cfg.statement;
 import java.util.Objects;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
 
 /**
  * A literal, representing a constant value.
@@ -19,16 +21,17 @@ public class Literal extends Expression {
 	/**
 	 * Builds the literal, consisting of a constant value. The location where this
 	 * literal happens is unknown (i.e. no source file/line/column is available).
+	 * The type of this literal is unknown (i.e. its type is {@code Untyped.INSTANCE}).
 	 * 
 	 * @param cfg   the cfg that this expression belongs to
 	 * @param value the value of this literal
 	 */
 	public Literal(CFG cfg, Object value) {
-		this(cfg, null, -1, -1, value);
+		this(cfg, null, -1, -1, value, Untyped.INSTANCE);
 	}
 
 	/**
-	 * Builds the literal, consisting of a constant value, happening at the given
+	 * Builds the typed literal, consisting of a constant value, happening at the given
 	 * location in the program.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
@@ -39,9 +42,30 @@ public class Literal extends Expression {
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
 	 * @param value      the value of this literal
+	 * @param type		 the type of this literal
+	 */
+	public Literal(CFG cfg, String sourceFile, int line, int col, Object value, Type type) {
+		super(cfg, sourceFile, line, col, type);
+		Objects.requireNonNull(value, "The value of a literal cannot be null");
+		this.value = value;
+	}
+	
+	/**
+	 * Builds the untyped literal, consisting of a constant value, happening at the given
+	 * location in the program.
+	 * 
+	 * @param cfg        the cfg that this expression belongs to
+	 * @param sourceFile the source file where this expression happens. If unknown,
+	 *                   use {@code null}
+	 * @param line       the line number where this expression happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param col        the column where this expression happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param value      the value of this literal
+	 * @param type		 the type of this literal
 	 */
 	public Literal(CFG cfg, String sourceFile, int line, int col, Object value) {
-		super(cfg, sourceFile, line, col);
+		super(cfg, sourceFile, line, col, Untyped.INSTANCE);
 		Objects.requireNonNull(value, "The value of a literal cannot be null");
 		this.value = value;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Literal.java
@@ -21,13 +21,25 @@ public class Literal extends Expression {
 	/**
 	 * Builds the literal, consisting of a constant value. The location where this
 	 * literal happens is unknown (i.e. no source file/line/column is available).
-	 * The type of this literal is unknown (i.e. its type is {@code Untyped.INSTANCE}).
+	 * The type of this literal is unknown (i.e. its type is {@link Untyped#INSTANCE}).
 	 * 
 	 * @param cfg   the cfg that this expression belongs to
 	 * @param value the value of this literal
 	 */
 	public Literal(CFG cfg, Object value) {
 		this(cfg, null, -1, -1, value, Untyped.INSTANCE);
+	}
+	
+	/**
+	 * Builds the literal, consisting of a constant value. The location where this
+	 * literal happens is unknown (i.e. no source file/line/column is available).
+	 * 
+	 * @param cfg   the cfg that this expression belongs to
+	 * @param value the value of this literal
+	 * @param type	the type of this literal
+	 */
+	public Literal(CFG cfg, Object value, Type type) {
+		this(cfg, null, -1, -1, value, type);
 	}
 
 	/**
@@ -62,7 +74,7 @@ public class Literal extends Expression {
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
 	 * @param value      the value of this literal
-	 * @param type		 the type of this literal
+	 * @param staticType the type of this literal
 	 */
 	public Literal(CFG cfg, String sourceFile, int line, int col, Object value) {
 		super(cfg, sourceFile, line, col, Untyped.INSTANCE);

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/NullLiteral.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/NullLiteral.java
@@ -1,6 +1,7 @@
 package it.unive.lisa.cfg.statement;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.NullType;
 
 /**
  * A literal representing the {@code null} constant.
@@ -14,15 +15,17 @@ public class NullLiteral extends Literal {
 	/**
 	 * Builds the null literal. The location where this literal happens is unknown
 	 * (i.e. no source file/line/column is available).
+	 * The type of a null literal is {@link NullType}.
 	 * 
 	 * @param cfg the cfg that this expression belongs to
 	 */
 	public NullLiteral(CFG cfg) {
-		super(cfg, NULL_CONST);
+		super(cfg, NULL_CONST, NullType.INSTANCE);
 	}
 
 	/**
 	 * Builds the null literal, happening at the given location in the program.
+	 * The type of a null literal is {@link NullType}.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -33,7 +36,7 @@ public class NullLiteral extends Literal {
 	 *                   file. If unknown, use {@code -1}
 	 */
 	public NullLiteral(CFG cfg, String sourceFile, int line, int col) {
-		super(cfg, sourceFile, line, col, NULL_CONST);
+		super(cfg, sourceFile, line, col, NULL_CONST, NullType.INSTANCE);
 	}
 
 	@Override

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Parameter.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Parameter.java
@@ -1,0 +1,169 @@
+package it.unive.lisa.cfg.statement;
+
+import java.util.Objects;
+
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
+
+/**
+ * A reference to a CFG parameter identified by its name and its type, containing
+ * the information about the source file, line and column where a parameter appears.
+ * No information about the CFG where the parameter appears is contained.
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public class Parameter {
+
+	/**
+	 * The source file where this parameter happens. If it is unknown, this field
+	 * might contain {@code null}.
+	 */
+	private final String sourceFile;
+
+	/**
+	 * The line where this parameter happens in the source file. If it is unknown,
+	 * this field might contain {@code -1}.
+	 */
+	private final int line;
+
+	/**
+	 * The column where this parameter happens in the source file. If it is unknown,
+	 * this field might contain {@code -1}.
+	 */
+	private final int col;
+	
+	/**
+	 * The name of this parameter
+	 */
+	private final String name;
+
+	/**
+	 * The static type of this parameter
+	 */
+	private final Type staticType;
+	
+	/**
+	 * Builds an untyped parameter reference, identified by its name. 
+	 * The location where this parameter reference happens is unknown 
+	 * (i.e. no source file/line/column is available) as well as
+	 * its type (i.e. it is {#link Untyped#INSTANCE}).
+	 * 
+	 * @param name       the name of this parameter
+	 */
+	public Parameter(String name) {
+		this(null, -1, -1, name, Untyped.INSTANCE);
+	}
+	
+	/**
+	 * Builds a typed parameter reference, identified by its name and its type. 
+	 * The location where this parameter reference happens is unknown 
+	 * (i.e. no source file/line/column is available).
+	 * 
+	 * @param name       the name of this parameter
+	 * @param staticType the type of this parameter
+	 */
+	public Parameter(String name, Type staticType) {
+		this(null, -1, -1, name, staticType);
+	}
+
+	/**
+	 * Builds the parameter reference, identified by its name and its type, 
+	 * happening at the given location in the program.
+	 * 
+	 * @param sourceFile the source file where this parameter happens. If unknown,
+	 *                   use {@code null}
+	 * @param line       the line number where this parameter happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param col        the column where this parameter happens in the source
+	 *                   file. If unknown, use {@code -1}
+	 * @param name       the name of this parameter
+	 * @param staticType the type of this parameter. If unknown,
+	 * 					 use {@link Untyped#INSTANCE}
+	 */
+	public Parameter(String sourceFile, int line, int col, String name, Type staticType) {
+		Objects.requireNonNull(name, "The name of a parameter cannot be null");
+		Objects.requireNonNull(staticType, "The type of a parameter cannot be null");
+		this.sourceFile = sourceFile;
+		this.line = line;
+		this.col = col;
+		this.name = name;
+		this.staticType = staticType;
+	}
+
+	/**
+	 * Yields the name of this parameter.
+	 * 
+	 * @return the name of this parameter
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Yields the static type of this parameter.
+	 * 
+	 * @return the static type of this parameter
+	 */
+	public Type getStaticType() {
+		return staticType;
+	}
+	
+	/**
+	 * Yields the line number where this parameter happens in the source file. 
+	 * This method returns {@code -1} if the line number is unknown.
+	 * 
+	 * @return the line number, or {@code -1}
+	 */
+	public final int getLine() {
+		return line;
+	}
+
+	/**
+	 * Yields the column where this parameter happens in the source file.
+	 * This method returns {@code -1} if the line number is unknown.
+	 * 
+	 * @return the column, or {@code -1}
+	 */
+	public final int getCol() {
+		return col;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + col;
+		result = prime * result + line;
+		result = prime * result + ((sourceFile == null) ? 0 : sourceFile.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
+		return result;
+	}
+
+	/**
+	 * Checks if this parameter is effectively equal to the given one, that is, if
+	 * they have the same structure while potentially being different instances, 
+	 * namely they have same name and same type.
+	 * 
+	 * @param other	 		the other parameter.
+	 * @return {@code true} if this parameter and the given one are effectively equals; 
+	 * 						{@code false} otherwise
+	 */
+	public boolean isEqualTo(Parameter other) {
+		if (this == other)
+			return true;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (!getStaticType().equals(other.getStaticType()))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return staticType + " " + name;
+	}	
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Parameter.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Parameter.java
@@ -134,30 +134,39 @@ public class Parameter {
 		int result = 1;
 		result = prime * result + col;
 		result = prime * result + line;
-		result = prime * result + ((sourceFile == null) ? 0 : sourceFile.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((sourceFile == null) ? 0 : sourceFile.hashCode());
 		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
 		return result;
 	}
-
-	/**
-	 * Checks if this parameter is effectively equal to the given one, that is, if
-	 * they have the same structure while potentially being different instances, 
-	 * namely they have same name and same type.
-	 * 
-	 * @param other	 		the other parameter.
-	 * @return {@code true} if this parameter and the given one are effectively equals; 
-	 * 						{@code false} otherwise
-	 */
-	public boolean isEqualTo(Parameter other) {
-		if (this == other)
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
 			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Parameter other = (Parameter) obj;
+		if (col != other.col)
+			return false;
+		if (line != other.line)
+			return false;
 		if (name == null) {
 			if (other.name != null)
 				return false;
 		} else if (!name.equals(other.name))
 			return false;
-		if (!getStaticType().equals(other.getStaticType()))
+		if (sourceFile == null) {
+			if (other.sourceFile != null)
+				return false;
+		} else if (!sourceFile.equals(other.sourceFile))
+			return false;
+		if (staticType == null) {
+			if (other.staticType != null)
+				return false;
+		} else if (!staticType.equals(other.staticType))
 			return false;
 		return true;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
@@ -29,6 +29,19 @@ public class Variable extends Expression {
 	public Variable(CFG cfg, String name) {
 		this(cfg, null, -1, -1, name, Untyped.INSTANCE);
 	}
+	
+	/**
+	 * Builds a typed variable reference, identified by its name and its type. The location where
+	 * this variable reference happens is unknown (i.e. no source file/line/column is
+	 * available).
+	 * 
+	 * @param cfg        the cfg that this expression belongs to
+	 * @param name       the name of this variable
+	 * @param type		 the type of this variable
+	 */
+	public Variable(CFG cfg, String name, Type type) {
+		this(cfg, null, -1, -1, name, type);
+	}
 
 	/**
 	 * Builds the variable reference, identified by its name, happening at the given
@@ -64,6 +77,7 @@ public class Variable extends Expression {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
 		return result;
 	}
 

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
@@ -3,6 +3,8 @@ package it.unive.lisa.cfg.statement;
 import java.util.Objects;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
 
 /**
  * A reference to a variable of the current CFG, identified by its name.
@@ -15,9 +17,9 @@ public class Variable extends Expression {
 	 * The name of this variable
 	 */
 	private final String name;
-	
+
 	/**
-	 * Builds the variable reference, identified by its name. The location where
+	 * Builds the untyped variable reference, identified by its name. The location where
 	 * this variable reference happens is unknown (i.e. no source file/line/column is
 	 * available).
 	 * 
@@ -25,7 +27,7 @@ public class Variable extends Expression {
 	 * @param name       the name of this variable
 	 */
 	public Variable(CFG cfg, String name) {
-		this(cfg, null, -1, -1, name);
+		this(cfg, null, -1, -1, name, Untyped.INSTANCE);
 	}
 
 	/**
@@ -40,9 +42,10 @@ public class Variable extends Expression {
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
 	 * @param name       the name of this variable
+	 * @param type		 the type of this variable
 	 */
-	public Variable(CFG cfg, String sourceFile, int line, int col, String name) {
-		super(cfg, sourceFile, line, col);
+	public Variable(CFG cfg, String sourceFile, int line, int col, String name, Type type) {
+		super(cfg, sourceFile, line, col, type);
 		Objects.requireNonNull(name, "The name of a variable cannot be null");
 		this.name = name;
 	}
@@ -75,6 +78,8 @@ public class Variable extends Expression {
 			if (other.name != null)
 				return false;
 		} else if (!name.equals(other.name))
+			return false;
+		if (!getType().equals(other.getType()))
 			return false;
 		return true;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Variable.java
@@ -21,7 +21,7 @@ public class Variable extends Expression {
 	/**
 	 * Builds the untyped variable reference, identified by its name. The location where
 	 * this variable reference happens is unknown (i.e. no source file/line/column is
-	 * available).
+	 * available) and its type is {@link Untyped#INSTANCE}.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param name       the name of this variable
@@ -31,9 +31,9 @@ public class Variable extends Expression {
 	}
 	
 	/**
-	 * Builds a typed variable reference, identified by its name and its type. The location where
-	 * this variable reference happens is unknown (i.e. no source file/line/column is
-	 * available).
+	 * Builds a typed variable reference, identified by its name and its type. 
+	 * The location where this variable reference happens is unknown 
+	 * (i.e. no source file/line/column is available).
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param name       the name of this variable
@@ -77,7 +77,7 @@ public class Variable extends Expression {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
 		return result;
 	}
 
@@ -93,7 +93,7 @@ public class Variable extends Expression {
 				return false;
 		} else if (!name.equals(other.name))
 			return false;
-		if (!getType().equals(other.getType()))
+		if (!getStaticType().equals(other.getStaticType()))
 			return false;
 		return true;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/BooleanType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/BooleanType.java
@@ -1,0 +1,10 @@
+package it.unive.lisa.cfg.type;
+
+/**
+ * Boolean type interface.
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public interface BooleanType extends Type {
+
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/BooleanType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/BooleanType.java
@@ -1,7 +1,8 @@
 package it.unive.lisa.cfg.type;
 
 /**
- * Boolean type interface.
+ * Boolean type interface. Any concrete Boolean type or Boolean sub-interface 
+ * should implement/extend this interface.
  * 
  * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
  */

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NullType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NullType.java
@@ -22,4 +22,14 @@ public class NullType implements Type {
 	public String toString() {
 		return "null";
 	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof NullType;
+	}
+	
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NullType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NullType.java
@@ -1,0 +1,25 @@
+package it.unive.lisa.cfg.type;
+
+/**
+ * The Null type, that is the type of {#link NullLiteral}.
+ * 
+ * It implements the singleton design pattern, that is 
+ * the instances of this type are unique. The unique instance of
+ * this type can be retrieved by {@link NullType#INSTANCE}.
+ *  
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public class NullType implements Type {
+	
+	/**
+	 * Unique instance of {@link NullType}. 
+	 */
+	public static final NullType INSTANCE = new NullType();
+	
+	private NullType() {}
+
+	@Override
+	public String toString() {
+		return "null";
+	}
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
@@ -1,0 +1,10 @@
+package it.unive.lisa.cfg.type;
+
+/**
+ * Numeric type interface.
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public interface NumericType extends Type {
+
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
@@ -1,7 +1,8 @@
 package it.unive.lisa.cfg.type;
 
 /**
- * Numeric type interface.
+ * Numeric type interface. Any concrete numerical type or numerical sub-interface 
+ * should implement/extend this interface.
  * 
  * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
  */

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
@@ -7,4 +7,41 @@ package it.unive.lisa.cfg.type;
  */
 public interface NumericType extends Type {
 
+	/**
+	 * Returns true if this numeric type follows a 8-bits format representation.
+	 * 
+	 * @return true if this numeric type follows a 8-bits format representation; false otherwise 
+	 */
+	public boolean is8Bits();
+	
+	/**
+	 * Returns true if this numeric type follows a 32-bits format representation.
+	 * 
+	 * @return true if this numeric type follows a 32-bits format representation; false otherwise
+	 */
+	
+	public boolean is32Bits();
+	
+	/**
+	 * Returns whether this numeric type follows a 64-bits format representation.
+	 * 
+	 * @return true if this numeric type follows a 64-bits format representation; false otherwise 
+	 */
+	public boolean is64its();
+	
+	/**
+	 * Returns true if this numeric type is unsigned.
+	 *  
+	 * @return true if this numeric type is unsigned; false otherwise
+	 */
+	public boolean isUnsigned();
+	
+	/**
+	 * Returns true if this numeric type is signed. 
+	 *  
+	 * @return true if this numeric type is signed; false otherwise
+	 */
+	public default boolean isSigned() {
+		return !isUnsigned();
+	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/StringType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/StringType.java
@@ -1,0 +1,10 @@
+package it.unive.lisa.cfg.type;
+
+/**
+ * String type interface.
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public interface StringType extends Type {
+
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/StringType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/StringType.java
@@ -1,7 +1,8 @@
 package it.unive.lisa.cfg.type;
 
 /**
- * String type interface.
+ * String type interface. Any concrete string type or string sub-interface 
+ * should implement/extend this interface.
  * 
  * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
  */

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
@@ -55,7 +55,7 @@ public interface Type {
 	/**
 	 * Returns this as Boolean type.
 	 * 
-	 * @return this as Boolean type if it is boolean; null otherwise.
+	 * @return this as Boolean type if it is Boolean; null otherwise.
 	 */
 	public default BooleanType asBoolean() {
 		return isBoolean() ? (BooleanType) this : null;

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
@@ -1,0 +1,72 @@
+package it.unive.lisa.cfg.type;
+
+/**
+ * Type interface.
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
+public interface Type {
+	
+	/**
+	 * Checks if this is a numeric type.
+	 * 
+	 * @return true if this is a numeric type; false otherwise.
+	 */
+	public default boolean isNumeric() {
+		return this instanceof NumericType;
+	}
+
+	/**
+	 * Checks if this is a boolean type
+	 * 
+	 * @return true if this is a Boolean type; false otherwise.
+	 */
+	public default boolean isBoolean() {
+		return this instanceof BooleanType;
+	}
+	
+	/**
+	 * Checks if this is a string type
+	 * 
+	 * @return true if this is a string type; false otherwise.
+	 */
+	public default boolean isString() {
+		return this instanceof StringType;
+	}
+	
+	/**
+	 * Returns true if this is untyped.
+	 * 
+	 * @return true if this is a untyped; false otherwise.
+	 */
+	public default boolean isUntyped() {
+		return this instanceof Untyped;
+	}
+	
+	/**
+	 * Returns this as numeric type.
+	 * 
+	 * @return this as numeric type if it is numeric; null otherwise.
+	 */
+	public default NumericType asNumeric() {
+		return isNumeric() ? (NumericType) this : null;
+	}
+	
+	/**
+	 * Returns this as Boolean type.
+	 * 
+	 * @return this as Boolean type if it is boolean; null otherwise.
+	 */
+	public default BooleanType asBoolean() {
+		return isBoolean() ? (BooleanType) this : null;
+	}
+	
+	/**
+	 * Returns this as string type.
+	 * 
+	 * @return this as string type if it is string; null otherwise.
+	 */
+	public default StringType asString() {
+		return isString() ? (StringType) this : null;
+	}
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Type.java
@@ -1,7 +1,9 @@
 package it.unive.lisa.cfg.type;
 
 /**
- * Type interface.
+ * Type interface. Any instance of a concrete type, instance of Type, 
+ * should be unique and implemented following the singleton design pattern
+ * (see for instance {@link Untyped} class).
  * 
  * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
  */

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
@@ -1,5 +1,10 @@
 package it.unive.lisa.cfg.type;
 
+/**
+ * The (singleton) untyped type. 
+ * 
+ * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
+ */
 public enum Untyped implements Type {
 	INSTANCE;
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
@@ -1,0 +1,5 @@
+package it.unive.lisa.cfg.type;
+
+public enum Untyped implements Type {
+	INSTANCE;
+}

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
@@ -1,10 +1,22 @@
 package it.unive.lisa.cfg.type;
 
 /**
- * The (singleton) untyped type. 
+ * The untyped type, corresponding to an unknown/untyped type. This type
+ * is used as default when no type information is provided for LiSA constructs
+ * (e.g., expression, variable, CFG return type).
  * 
+ * It implements the singleton design pattern, that is 
+ * the instances of this type are unique. The unique instance of
+ * this type can be retrieved by {@link Untyped#INSTANCE}.
+ *  
  * @author <a href="mailto:vincenzo.arceri@unive.it">Vincenzo Arceri</a>
  */
-public enum Untyped implements Type {
-	INSTANCE;
+public class Untyped implements Type {
+	
+	/**
+	 * Unique instance of Untyped type. 
+	 */
+	public static final Untyped INSTANCE = new Untyped();
+	
+	private Untyped() {}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
@@ -19,4 +19,9 @@ public class Untyped implements Type {
 	public static final Untyped INSTANCE = new Untyped();
 	
 	private Untyped() {}
+
+	@Override
+	public String toString() {
+		return "untyped";
+	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/Untyped.java
@@ -24,4 +24,14 @@ public class Untyped implements Type {
 	public String toString() {
 		return "untyped";
 	}
+	
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof Untyped;
+	}
+	
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
+++ b/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
@@ -13,6 +13,7 @@ import it.unive.lisa.cfg.statement.Assignment;
 import it.unive.lisa.cfg.statement.Expression;
 import it.unive.lisa.cfg.statement.Literal;
 import it.unive.lisa.cfg.statement.OpenCall;
+import it.unive.lisa.cfg.statement.Parameter;
 import it.unive.lisa.cfg.statement.Return;
 import it.unive.lisa.cfg.statement.Statement;
 import it.unive.lisa.cfg.statement.Throw;
@@ -53,7 +54,7 @@ public class SyntacticCheckTest {
 		LiSA lisa = new LiSA();
 		lisa.addSyntacticCheck(new VariableI());
 
-		CFG cfg = new CFG(new CFGDescriptor("foo", new Variable[0]));
+		CFG cfg = new CFG(new CFGDescriptor("foo", new Parameter[0]));
 		cfgFiller.accept(cfg);
 		lisa.addCFG(cfg);
 		lisa.run();

--- a/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
+++ b/lisa/src/test/java/it/unive/lisa/test/checks/syntactic/SyntacticCheckTest.java
@@ -10,8 +10,6 @@ import it.unive.lisa.LiSA;
 import it.unive.lisa.cfg.CFG;
 import it.unive.lisa.cfg.CFGDescriptor;
 import it.unive.lisa.cfg.statement.Assignment;
-import it.unive.lisa.cfg.statement.CFGCall;
-import it.unive.lisa.cfg.statement.Call;
 import it.unive.lisa.cfg.statement.Expression;
 import it.unive.lisa.cfg.statement.Literal;
 import it.unive.lisa.cfg.statement.OpenCall;
@@ -21,7 +19,6 @@ import it.unive.lisa.cfg.statement.Throw;
 import it.unive.lisa.cfg.statement.Variable;
 import it.unive.lisa.checks.CheckTool;
 import it.unive.lisa.checks.syntactic.SyntacticCheck;
-import it.unive.lisa.checks.warnings.Warning;
 
 public class SyntacticCheckTest {
 
@@ -56,7 +53,7 @@ public class SyntacticCheckTest {
 		LiSA lisa = new LiSA();
 		lisa.addSyntacticCheck(new VariableI());
 
-		CFG cfg = new CFG(new CFGDescriptor("foo", new String[0]));
+		CFG cfg = new CFG(new CFGDescriptor("foo", new Variable[0]));
 		cfgFiller.accept(cfg);
 		lisa.addCFG(cfg);
 		lisa.run();


### PR DESCRIPTION
**Description**
Added static typing information to LiSA, following the suggested implementation reported in #9.  
- The type interface ```Type``` has been added, extended by the type sub-interfaces ```NumericType```, ```BooleanType``` and ```StringType```;
- No concrete type has been introduced except for the type ```Untyped```, implemented as a singleton. Any concrete type that will be defined in the future should be implemented following the singleton design pattern;
- The static type information has been added to ```Expression``` as a protected field: when the type is not provided, ```Untyped``` type is used as default;
- The return type of ```CFG``` is captured by its descriptor, namely ```CFGDescriptor```, with the protected field ```returnType```: as above, if no return type is provided for the descriptor, ```Untyped```type is used as default.
- In ```CFGDescriptor```, the type of the arguments names (```argNames```) was changed from array of strings (```String[]```) to array of variables (```Variable[]```). In this way, it possible to capture the arguments names together with their types (since ```Variable```has static type information being an expression).
- Also ```Literal```, being an expression, has static type information. LiSA has only the concrete literal ```NullLiteral```and for the moment it has no type information (namely, the type of ```NullLiteral``` is  ```Untyped```). Should be implement the LiSA internal type ```NullType```?

**Implemented features**
Closes #9 