### PR TITLE
Added static types information to calls (open, native and CFG calls)

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -75,6 +75,32 @@ public class CFGDescriptor {
 	}
 
 	/**
+	 * Builds the descriptor with {@link Untyped} return type.
+	 * 
+	 * @param sourceFile the source file where the CFG associated with this
+	 *                   descriptor is defined. If unknown, use {@code null}
+	 * @param line       the line number where the CFG associated with this
+	 *                   descriptor is defined in the source file. If unknown, use
+	 *                   {@code -1}
+	 * @param col        the column where the CFG associated with this descriptor is
+	 *                   defined in the source file. If unknown, use {@code -1}
+	 * @param name       the name of the CFG associated with this descriptor
+	 * @param args   	 the arguments of the CFG associated with this descriptor                
+	 */
+	public CFGDescriptor(String sourceFile, int line, int col, String name, Parameter... args) {
+		Objects.requireNonNull(name, "The name of a CFG cannot be null");
+		Objects.requireNonNull(args, "The array of argument names of a CFG cannot be null");
+		for (int i = 0; i < args.length; i++)
+			Objects.requireNonNull(args[i], "The " + i + "-th argument name of a CFG cannot be null");
+		this.sourceFile = sourceFile;
+		this.line = line;
+		this.col = col;
+		this.name = name;
+		this.args = args;
+		this.returnType = Untyped.INSTANCE;
+	}
+	
+	/**
 	 * Builds the descriptor.
 	 * 
 	 * @param sourceFile the source file where the CFG associated with this

--- a/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/CFGDescriptor.java
@@ -88,16 +88,7 @@ public class CFGDescriptor {
 	 * @param args   	 the arguments of the CFG associated with this descriptor                
 	 */
 	public CFGDescriptor(String sourceFile, int line, int col, String name, Parameter... args) {
-		Objects.requireNonNull(name, "The name of a CFG cannot be null");
-		Objects.requireNonNull(args, "The array of argument names of a CFG cannot be null");
-		for (int i = 0; i < args.length; i++)
-			Objects.requireNonNull(args[i], "The " + i + "-th argument name of a CFG cannot be null");
-		this.sourceFile = sourceFile;
-		this.line = line;
-		this.col = col;
-		this.name = name;
-		this.args = args;
-		this.returnType = Untyped.INSTANCE;
+		this(sourceFile, line, col, name, Untyped.INSTANCE, args);
 	}
 	
 	/**

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import it.unive.lisa.cfg.CFG;
 
 /**
- * A call to one of the CFG under analysis.
+ * A call to one of the CFG under analysis. 
  * 
  * @author <a href="mailto:luca.negrini@unive.it">Luca Negrini</a>
  */
@@ -27,11 +27,12 @@ public class CFGCall extends Call {
 	 * @param parameters the parameters of this call
 	 */
 	public CFGCall(CFG cfg, CFG target, Expression... parameters) {
-		this(cfg, null, -1, -1, target, parameters);
+		this(cfg, null, -1, -1, target, parameters);		
 	}
 
 	/**
-	 * Builds the CFG call, happening at the given location in the program.
+	 * Builds the CFG call, happening at the given location in the program. 
+	 * The static type of this CFGCall is the one return type of the descriptor of {@code target}.
 	 * 
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param sourceFile the source file where this expression happens. If unknown,
@@ -44,7 +45,7 @@ public class CFGCall extends Call {
 	 * @param parameters the parameters of this call
 	 */
 	public CFGCall(CFG cfg, String sourceFile, int line, int col, CFG target, Expression... parameters) {
-		super(cfg, sourceFile, line, col, parameters);
+		super(cfg, sourceFile, line, col, target.getDescriptor().getReturnType(), parameters);
 		Objects.requireNonNull(target, "The target of a CFG call cannot be null");
 		this.target = target;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Call.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Call.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
 
 /**
  * A call to another procedure. This concrete instance of this class determines
@@ -31,9 +32,10 @@ public abstract class Call extends Expression {
 	 * @param col        the column where this expression happens in the source
 	 *                   file. If unknown, use {@code -1}
 	 * @param parameters the parameters of this call
+	 * @param staticType the static type of this call
 	 */
-	protected Call(CFG cfg, String sourceFile, int line, int col, Expression... parameters) {
-		super(cfg, sourceFile, line, col);
+	protected Call(CFG cfg, String sourceFile, int line, int col, Type staticType, Expression... parameters) {
+		super(cfg, sourceFile, line, col, staticType);
 		Objects.requireNonNull(parameters, "The array of parameters of a call cannot be null");
 		for (int i = 0; i < parameters.length; i++)
 			Objects.requireNonNull(parameters[i], "The " + i + "-th parameter of a call cannot be null");
@@ -54,6 +56,7 @@ public abstract class Call extends Expression {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + Arrays.hashCode(parameters);
+		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
 		return result;
 	}
 
@@ -65,6 +68,8 @@ public abstract class Call extends Expression {
 			return false;
 		Call other = (Call) st;
 		if (!areEquals(parameters, other.parameters))
+			return false;
+		if (!getStaticType().equals(other.getStaticType()))
 			return false;
 		return true;
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/NativeCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/NativeCall.java
@@ -61,9 +61,7 @@ public abstract class NativeCall extends Call {
 	 * @param parameters    the parameters of this call
 	 */
 	protected NativeCall(CFG cfg, String sourceFile, int line, int col, String constructName, Expression... parameters) {
-		super(cfg, sourceFile, line, col, Untyped.INSTANCE, parameters);
-		Objects.requireNonNull(constructName, "The name of the native construct of a native call cannot be null");
-		this.constructName = constructName;
+		this(cfg, sourceFile, line, col, constructName, Untyped.INSTANCE, parameters);
 	}
 	
 	/**

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/NativeCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/NativeCall.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
 
 /**
  * A native call, modeling the usage of one of the native constructs of the
@@ -20,19 +22,33 @@ public abstract class NativeCall extends Call {
 	private final String constructName;
 
 	/**
-	 * Builds the native call. The location where this call happens is unknown (i.e.
-	 * no source file/line/column is available).
+	 * Builds the untyped native call. The location where this call happens is unknown (i.e.
+	 * no source file/line/column is available). The static type of this call is {@link Untyped}.
 	 * 
 	 * @param cfg           the cfg that this expression belongs to
 	 * @param constructName the name of the construct invoked by this native call
 	 * @param parameters    the parameters of this call
 	 */
 	protected NativeCall(CFG cfg, String constructName, Expression... parameters) {
-		this(cfg, null, -1, -1, constructName, parameters);
+		this(cfg, null, -1, -1, constructName, Untyped.INSTANCE, parameters);
+	}
+	
+	/**
+	 * Builds the native call. The location where this call happens is unknown (i.e.
+	 * no source file/line/column is available).
+	 * 
+	 * @param cfg           the cfg that this expression belongs to
+	 * @param constructName the name of the construct invoked by this native call
+	 * @param parameters    the parameters of this call
+	 * @param staticType    the static type of this call
+	 */
+	protected NativeCall(CFG cfg, String constructName, Type staticType, Expression... parameters) {
+		this(cfg, null, -1, -1, constructName, staticType, parameters);
 	}
 
 	/**
-	 * Builds the CFG call, happening at the given location in the program.
+	 * Builds the untyped native call, happening at the given location in the program.
+	 * The static type of this call is {@link Untyped}.
 	 * 
 	 * @param cfg           the cfg that this expression belongs to
 	 * @param sourceFile    the source file where this expression happens. If
@@ -45,7 +61,27 @@ public abstract class NativeCall extends Call {
 	 * @param parameters    the parameters of this call
 	 */
 	protected NativeCall(CFG cfg, String sourceFile, int line, int col, String constructName, Expression... parameters) {
-		super(cfg, sourceFile, line, col, parameters);
+		super(cfg, sourceFile, line, col, Untyped.INSTANCE, parameters);
+		Objects.requireNonNull(constructName, "The name of the native construct of a native call cannot be null");
+		this.constructName = constructName;
+	}
+	
+	/**
+	 * Builds the native call, happening at the given location in the program.
+	 * 
+	 * @param cfg           the cfg that this expression belongs to
+	 * @param sourceFile    the source file where this expression happens. If
+	 *                      unknown, use {@code null}
+	 * @param line          the line number where this expression happens in the
+	 *                      source file. If unknown, use {@code -1}
+	 * @param col           the column where this expression happens in the source
+	 *                      file. If unknown, use {@code -1}
+	 * @param constructName the name of the construct invoked by this native call
+	 * @param parameters    the parameters of this call
+	 * @param staticType	the static type of this call
+	 */
+	protected NativeCall(CFG cfg, String sourceFile, int line, int col, String constructName, Type staticType, Expression... parameters) {
+		super(cfg, sourceFile, line, col, staticType, parameters);
 		Objects.requireNonNull(constructName, "The name of the native construct of a native call cannot be null");
 		this.constructName = constructName;
 	}
@@ -64,6 +100,7 @@ public abstract class NativeCall extends Call {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((constructName == null) ? 0 : constructName.hashCode());
+		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
 		return result;
 	}
 
@@ -78,6 +115,8 @@ public abstract class NativeCall extends Call {
 			if (other.constructName != null)
 				return false;
 		} else if (!constructName.equals(other.constructName))
+			return false;
+		if (!getStaticType().equals(other.getStaticType()))
 			return false;
 		return super.isEqualTo(other);
 	}

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/OpenCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/OpenCall.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 import it.unive.lisa.cfg.CFG;
+import it.unive.lisa.cfg.type.Type;
+import it.unive.lisa.cfg.type.Untyped;
 
 /**
  * A call to a CFG that is not under analysis.
@@ -18,6 +20,19 @@ public class OpenCall extends Call {
 	 */
 	private final String targetName;
 
+	
+	/**
+	 * Builds the untyped open call. The location where this call happens is unknown (i.e.
+	 * no source file/line/column is available). The static type of this call is {@link Untyped}.
+	 * 
+	 * @param cfg        the cfg that this expression belongs to
+	 * @param targetName the name of the target of this open call
+	 * @param parameters the parameters of this call
+	 */
+	public OpenCall(CFG cfg, String targetName, Expression... parameters) {
+		this(cfg, null, -1, -1, targetName, Untyped.INSTANCE, parameters);
+	}
+	
 	/**
 	 * Builds the open call. The location where this call happens is unknown (i.e.
 	 * no source file/line/column is available).
@@ -25,9 +40,10 @@ public class OpenCall extends Call {
 	 * @param cfg        the cfg that this expression belongs to
 	 * @param targetName the name of the target of this open call
 	 * @param parameters the parameters of this call
+	 * @param staticType the static type of this call
 	 */
-	public OpenCall(CFG cfg, String targetName, Expression... parameters) {
-		this(cfg, null, -1, -1, targetName, parameters);
+	public OpenCall(CFG cfg, String targetName, Type staticType, Expression... parameters) {
+		this(cfg, null, -1, -1, targetName, staticType, parameters);
 	}
 
 	/**
@@ -42,9 +58,10 @@ public class OpenCall extends Call {
 	 *                   file. If unknown, use {@code -1}
 	 * @param targetName the name of the target of this open call
 	 * @param parameters the parameters of this call
+	 * @param staticType the static type of this call
 	 */
-	public OpenCall(CFG cfg, String sourceFile, int line, int col, String targetName, Expression... parameters) {
-		super(cfg, sourceFile, line, col, parameters);
+	public OpenCall(CFG cfg, String sourceFile, int line, int col, String targetName, Type staticType, Expression... parameters) {
+		super(cfg, sourceFile, line, col, staticType, parameters);
 		Objects.requireNonNull(targetName, "The name of the target of an open call cannot be null");
 		this.targetName = targetName;
 	}
@@ -63,6 +80,7 @@ public class OpenCall extends Call {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((targetName == null) ? 0 : targetName.hashCode());
+		result = prime * result + ((staticType == null) ? 0 : staticType.hashCode());
 		return result;
 	}
 
@@ -78,11 +96,13 @@ public class OpenCall extends Call {
 				return false;
 		} else if (!targetName.equals(other.targetName))
 			return false;
+		if (!getStaticType().equals(other.getStaticType()))
+			return false;
 		return super.isEqualTo(other);
 	}
 
 	@Override
 	public String toString() {
-		return targetName + "(" + StringUtils.join(getParameters(), ", ") + ")";
+		return getStaticType() + " " + targetName + "(" + StringUtils.join(getParameters(), ", ") + ")";
 	}
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/type/NumericType.java
@@ -9,38 +9,44 @@ package it.unive.lisa.cfg.type;
 public interface NumericType extends Type {
 
 	/**
-	 * Returns true if this numeric type follows a 8-bits format representation.
+	 * Returns {@code true} if this numeric type follows a 8-bits format representation.
 	 * 
-	 * @return true if this numeric type follows a 8-bits format representation; false otherwise 
+	 * @return {@code true} if this numeric type follows a 8-bits format representation; {@code false} otherwise 
 	 */
 	public boolean is8Bits();
 	
 	/**
-	 * Returns true if this numeric type follows a 32-bits format representation.
+	 * Returns {@code true} if this numeric type follows a 16-bits format representation.
 	 * 
-	 * @return true if this numeric type follows a 32-bits format representation; false otherwise
+	 * @return {@code true} if this numeric type follows a 16-bits format representation; {@code false} otherwise
 	 */
+	public boolean is16Bits();
 	
+	/**
+	 * Returns {@code true} if this numeric type follows a 32-bits format representation.
+	 * 
+	 * @return {@code true} if this numeric type follows a 32-bits format representation; {@code false} otherwise
+	 */
 	public boolean is32Bits();
 	
 	/**
-	 * Returns whether this numeric type follows a 64-bits format representation.
+	 * Returns {@code true} if this numeric type follows a 64-bits format representation.
 	 * 
-	 * @return true if this numeric type follows a 64-bits format representation; false otherwise 
+	 * @return {@code true} if this numeric type follows a 64-bits format representation; {@code false} otherwise 
 	 */
-	public boolean is64its();
+	public boolean is64Bits();
 	
 	/**
-	 * Returns true if this numeric type is unsigned.
+	 * Returns {@code true} if this numeric type is unsigned.
 	 *  
-	 * @return true if this numeric type is unsigned; false otherwise
+	 * @return {@code true} if this numeric type is unsigned; {@code false} otherwise
 	 */
 	public boolean isUnsigned();
 	
 	/**
-	 * Returns true if this numeric type is signed. 
+	 * Returns {@code true} if this numeric type is signed. 
 	 *  
-	 * @return true if this numeric type is signed; false otherwise
+	 * @return {@code true} if this numeric type is signed; {@code false} otherwise
 	 */
 	public default boolean isSigned() {
 		return !isUnsigned();


### PR DESCRIPTION
**Description**
In the pull request #10 was missing the information about the static types for calls of LiSA CFG: ```OpenCall```, ```NativeCall``` and ```CFGCall```. Now it is possible to define the static type of these calls. In particular:
- it is possible to set the static type of ```OpenCall``` and ```NativeCall```
- the static type of a ```CFGCall``` is retrieved from the ```CFGDescriptor``` of his ```CFG``` target
 
**Further content**
Related to pull request #10 
