### PR TITLE
Refactoring call semantics with intermediate states of the parameters evaluation

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
@@ -192,8 +192,12 @@ public class CFGCall extends Call implements MetaVariableCreator {
 					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
 		// it corresponds to the analysis state after the evaluation of all the
-		// parameter of this call
-		AnalysisState<A, H, TypeEnvironment> lastPostState = computedStates[computedStates.length - 1];
+		// parameters of this call, it is the entry state if this call has no
+		// parameters
+		// (the semantics of this call does not need information about the
+		// intermediate analysis states)
+		AnalysisState<A, H, TypeEnvironment> lastPostState = computedStates.length == 0 ? entryState
+				: computedStates[computedStates.length - 1];
 
 		// this will contain only the information about the returned
 		// metavariable
@@ -233,10 +237,12 @@ public class CFGCall extends Call implements MetaVariableCreator {
 					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
 		// it corresponds to the analysis state after the evaluation of all the
-		// parameters of this call
+		// parameters of this call, it is the entry state if this call has no
+		// parameters
 		// (the semantics of this call does not need information about the
 		// intermediate analysis states)
-		AnalysisState<A, H, V> lastPostState = computedStates[computedStates.length - 1];
+		AnalysisState<A, H,
+				V> lastPostState = computedStates.length == 0 ? entryState : computedStates[computedStates.length - 1];
 
 		// this will contain only the information about the returned
 		// metavariable

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/CFGCall.java
@@ -188,13 +188,18 @@ public class CFGCall extends Call implements MetaVariableCreator {
 	@Override
 	public <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
+		// it corresponds to the analysis state after the evaluation of all the
+		// parameter of this call
+		AnalysisState<A, H, TypeEnvironment> lastPostState = computedStates[computedStates.length - 1];
+
 		// this will contain only the information about the returned
 		// metavariable
-		AnalysisState<A, H, TypeEnvironment> returned = callGraph.getAbstractResultOf(this, computedState, params);
+		AnalysisState<A, H, TypeEnvironment> returned = callGraph.getAbstractResultOf(this, lastPostState, params);
 		// the lub will include the metavariable inside the state
-		AnalysisState<A, H, TypeEnvironment> lub = computedState.lub(returned).smallStepSemantics(new Skip());
+		AnalysisState<A, H, TypeEnvironment> lub = lastPostState.lub(returned).smallStepSemantics(new Skip());
 
 		AnalysisState<A, H, TypeEnvironment> result = null;
 		if (getStaticType().isVoidType())
@@ -224,13 +229,20 @@ public class CFGCall extends Call implements MetaVariableCreator {
 	public <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
+		// it corresponds to the analysis state after the evaluation of all the
+		// parameters of this call
+		// (the semantics of this call does not need information about the
+		// intermediate analysis states)
+		AnalysisState<A, H, V> lastPostState = computedStates[computedStates.length - 1];
+
 		// this will contain only the information about the returned
 		// metavariable
-		AnalysisState<A, H, V> returned = callGraph.getAbstractResultOf(this, computedState, params);
+		AnalysisState<A, H, V> returned = callGraph.getAbstractResultOf(this, lastPostState, params);
 		// the lub will include the metavariable inside the state
-		AnalysisState<A, H, V> lub = computedState.lub(returned);
+		AnalysisState<A, H, V> lub = lastPostState.lub(returned);
 
 		if (getStaticType().isVoidType())
 			// no need to add the meta variable since nothing has been pushed on

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/Call.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/Call.java
@@ -130,14 +130,16 @@ public abstract class Call extends Expression {
 		@SuppressWarnings("unchecked")
 		Collection<SymbolicExpression>[] computed = new Collection[parameters.length];
 
-		AnalysisState<A, H, V> current = entryState;
+		@SuppressWarnings("unchecked")
+		AnalysisState<A, H, V>[] paramStates = new AnalysisState[parameters.length];
+		AnalysisState<A, H, V> preState = entryState;
 		for (int i = 0; i < computed.length; i++) {
-			current = parameters[i].semantics(current, callGraph, expressions);
-			expressions.put(parameters[i], current);
-			computed[i] = current.getComputedExpressions();
+			preState = paramStates[i] = parameters[i].semantics(preState, callGraph, expressions);
+			expressions.put(parameters[i], paramStates[i]);
+			computed[i] = paramStates[i].getComputedExpressions();
 		}
 
-		AnalysisState<A, H, V> result = callSemantics(current, callGraph, computed);
+		AnalysisState<A, H, V> result = callSemantics(entryState, callGraph, paramStates, computed);
 		for (Expression param : parameters)
 			if (!param.getMetaVariables().isEmpty())
 				result = result.forgetIdentifiers(param.getMetaVariables());
@@ -149,14 +151,21 @@ public abstract class Call extends Expression {
 	 * have been computed. Meta variables from the parameters will be forgotten
 	 * after this call returns.
 	 * 
-	 * @param <A>           the type of {@link AbstractState}
-	 * @param <H>           the type of the {@link HeapDomain}
-	 * @param <V>           the type of the {@link ValueDomain}
-	 * @param computedState the entry state that has been computed by chaining
-	 *                          the parameters' semantics evaluation
-	 * @param callGraph     the call graph of the program to analyze
-	 * @param params        the symbolic expressions representing the computed
-	 *                          values of the parameters of this call
+	 * @param <A>            the type of {@link AbstractState}
+	 * @param <H>            the type of the {@link HeapDomain}
+	 * @param <V>            the type of the {@link ValueDomain}
+	 * @param entryState     the entry state of this call
+	 * @param callGraph      the call graph of the program to analyze
+	 * @param computedStates the array of states chaining the parameters'
+	 *                           semantics evaluation starting from
+	 *                           {@code entryState}, namely
+	 *                           {@code computedState[i]} corresponds to the
+	 *                           state obtained by the evaluation of
+	 *                           {@code params[i]} in the state
+	 *                           {@code computedState[i-1]} ({@code params[0]}
+	 *                           is evaluated in {@code entryState})
+	 * @param params         the symbolic expressions representing the computed
+	 *                           values of the parameters of this call
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this call
@@ -166,7 +175,9 @@ public abstract class Call extends Expression {
 	public abstract <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState,
+					CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException;
 
 	@Override
@@ -177,14 +188,16 @@ public abstract class Call extends Expression {
 		@SuppressWarnings("unchecked")
 		Collection<SymbolicExpression>[] computed = new Collection[parameters.length];
 
-		AnalysisState<A, H, TypeEnvironment> current = entryState;
+		@SuppressWarnings("unchecked")
+		AnalysisState<A, H, TypeEnvironment>[] currents = new AnalysisState[parameters.length];
+
 		for (int i = 0; i < computed.length; i++) {
-			current = parameters[i].typeInference(current, callGraph, expressions);
-			expressions.put(parameters[i], current);
-			computed[i] = current.getComputedExpressions();
+			currents[i] = parameters[i].typeInference(entryState, callGraph, expressions);
+			expressions.put(parameters[i], currents[i]);
+			computed[i] = currents[i].getComputedExpressions();
 		}
 
-		AnalysisState<A, H, TypeEnvironment> result = callSemantics(current, callGraph, computed);
+		AnalysisState<A, H, TypeEnvironment> result = callSemantics(entryState, callGraph, currents, computed);
 		for (Expression param : parameters)
 			if (!param.getMetaVariables().isEmpty())
 				result = result.forgetIdentifiers(param.getMetaVariables());
@@ -196,13 +209,20 @@ public abstract class Call extends Expression {
 	 * inferred. Meta variables from the parameters will be forgotten after this
 	 * call returns.
 	 * 
-	 * @param <A>           the type of {@link AbstractState}
-	 * @param <H>           the type of the {@link HeapDomain}
-	 * @param computedState the entry state that has been computed by chaining
-	 *                          the parameters' type inference
-	 * @param callGraph     the call graph of the program to analyze
-	 * @param params        the symbolic expressions representing the computed
-	 *                          values of the parameters of this call
+	 * @param <A>            the type of {@link AbstractState}
+	 * @param <H>            the type of the {@link HeapDomain}
+	 * @param entryState     the entry state of this call
+	 * @param callGraph      the call graph of the program to analyze
+	 * @param computedStates the array of states chaining the parameters'
+	 *                           semantics evaluation starting from
+	 *                           {@code entryState}, namely
+	 *                           {@code computedState[i]} corresponds to the
+	 *                           state obtained by the evaluation of
+	 *                           {@code params[i]} in the state
+	 *                           {@code computedState[i-1]} ({@code params[0]}
+	 *                           is evaluated in {@code entryState})
+	 * @param params         the symbolic expressions representing the computed
+	 *                           values of the parameters of this call
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this call
@@ -211,7 +231,8 @@ public abstract class Call extends Expression {
 	 */
 	public abstract <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState,
+					CallGraph callGraph, AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params)
 					throws SemanticException;
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/OpenCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/OpenCall.java
@@ -124,10 +124,11 @@ public class OpenCall extends Call implements MetaVariableCreator {
 	@Override
 	public <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
 		// TODO too coarse
-		AnalysisState<A, H, TypeEnvironment> poststate = computedState.top();
+		AnalysisState<A, H, TypeEnvironment> poststate = entryState.top();
 
 		if (getStaticType().isVoidType())
 			poststate = poststate.smallStepSemantics(new Skip());
@@ -142,10 +143,11 @@ public class OpenCall extends Call implements MetaVariableCreator {
 	public <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
 		// TODO too coarse
-		AnalysisState<A, H, V> poststate = computedState.top();
+		AnalysisState<A, H, V> poststate = entryState.top();
 
 		if (getStaticType().isVoidType())
 			return poststate.smallStepSemantics(new Skip());

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/UnaryNativeCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/UnaryNativeCall.java
@@ -91,11 +91,12 @@ public abstract class UnaryNativeCall extends NativeCall {
 	@Override
 	public final <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
 		AnalysisState<A, H, TypeEnvironment> result = null;
 		for (SymbolicExpression expr : params[0]) {
-			AnalysisState<A, H, TypeEnvironment> tmp = unarySemantics(computedState, callGraph, expr);
+			AnalysisState<A, H, TypeEnvironment> tmp = unarySemantics(entryState, callGraph, computedStates[0], expr);
 			if (result == null)
 				result = tmp;
 			else
@@ -110,11 +111,13 @@ public abstract class UnaryNativeCall extends NativeCall {
 	public final <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState,
+					CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = null;
 		for (SymbolicExpression expr : params[0]) {
-			AnalysisState<A, H, V> tmp = unarySemantics(computedState, callGraph, expr);
+			AnalysisState<A, H, V> tmp = unarySemantics(entryState, callGraph, computedStates[0], expr);
 			if (result == null)
 				result = tmp;
 			else
@@ -128,14 +131,15 @@ public abstract class UnaryNativeCall extends NativeCall {
 	 * has been computed. Meta variables from the parameter will be forgotten
 	 * after this call returns.
 	 * 
-	 * @param <A>           the type of {@link AbstractState}
-	 * @param <H>           the type of the {@link HeapDomain}
-	 * @param <V>           the type of the {@link ValueDomain}
-	 * @param computedState the entry state that has been computed by chaining
-	 *                          the parameter's semantics evaluation
-	 * @param callGraph     the call graph of the program to analyze
-	 * @param expr          the symbolic expressions representing the computed
-	 *                          value of the parameter of this call
+	 * @param <A>        the type of {@link AbstractState}
+	 * @param <H>        the type of the {@link HeapDomain}
+	 * @param <V>        the type of the {@link ValueDomain}
+	 * @param entryState the entry state of this unary call
+	 * @param callGraph  the call graph of the program to analyze
+	 * @param exprState  the state obtained by evaluating {@code expr} in
+	 *                       {@code entryState}
+	 * @param expr       the symbolic expressions representing the computed
+	 *                       value of the parameter of this call
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this call
@@ -145,6 +149,7 @@ public abstract class UnaryNativeCall extends NativeCall {
 	protected abstract <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression expr)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V> exprState,
+					SymbolicExpression expr)
 					throws SemanticException;
 }

--- a/lisa/src/main/java/it/unive/lisa/cfg/statement/UnresolvedCall.java
+++ b/lisa/src/main/java/it/unive/lisa/cfg/statement/UnresolvedCall.java
@@ -105,10 +105,12 @@ public class UnresolvedCall extends Call {
 	@Override
 	public <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
 		Call resolved = callGraph.resolve(this);
-		AnalysisState<A, H, TypeEnvironment> result = resolved.callTypeInference(computedState, callGraph, params);
+		AnalysisState<A, H,
+				TypeEnvironment> result = resolved.callTypeInference(entryState, callGraph, computedStates, params);
 		getMetaVariables().addAll(resolved.getMetaVariables());
 		setRuntimeTypes(result.getState().getValueState().getLastComputedTypes().getRuntimeTypes());
 		return result;
@@ -118,11 +120,13 @@ public class UnresolvedCall extends Call {
 	public <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
+
 		Call resolved = callGraph.resolve(this);
 		resolved.setRuntimeTypes(getRuntimeTypes());
-		AnalysisState<A, H, V> result = resolved.callSemantics(computedState, callGraph, params);
+		AnalysisState<A, H, V> result = resolved.callSemantics(entryState, callGraph, computedStates, params);
 		getMetaVariables().addAll(resolved.getMetaVariables());
 		return result;
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/cfg/CFGSimplificationTest.java
+++ b/lisa/src/test/java/it/unive/lisa/test/cfg/CFGSimplificationTest.java
@@ -91,9 +91,11 @@ public class CFGSimplificationTest {
 			protected <A extends AbstractState<A, H, V>,
 					H extends HeapDomain<H>,
 					V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-							AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+							AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V> leftState,
+							SymbolicExpression left,
+							AnalysisState<A, H, V> rightState,
 							SymbolicExpression right) throws SemanticException {
-				return computedState;
+				return rightState;
 			}
 		}
 
@@ -106,9 +108,10 @@ public class CFGSimplificationTest {
 			protected <A extends AbstractState<A, H, V>,
 					H extends HeapDomain<H>,
 					V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
-							AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression expr)
+							AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V> exprState,
+							SymbolicExpression expr)
 							throws SemanticException {
-				return computedState;
+				return entryState;
 			}
 		}
 

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPAdd.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPAdd.java
@@ -51,8 +51,12 @@ public class IMPAdd extends BinaryNativeCall implements BinaryNumericalOperation
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		BinaryOperator op;
 		ExternalSet<Type> types;
@@ -64,9 +68,9 @@ public class IMPAdd extends BinaryNativeCall implements BinaryNumericalOperation
 			op = BinaryOperator.NUMERIC_ADD;
 			types = commonNumericalType(left, right);
 		} else
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(types, left, right, op));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPAnd.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPAnd.java
@@ -43,16 +43,20 @@ public class IMPAnd extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isBooleanType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isBooleanType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.LOGICAL_AND));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPArrayAccess.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPArrayAccess.java
@@ -36,19 +36,22 @@ public class IMPArrayAccess extends BinaryNativeCall {
 		super(cfg, sourceFile, line, col, "[]", container, location);
 	}
 
-	@Override
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		if (!left.getDynamicType().isArrayType() || !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		// it is not possible to detect the correct type of the field without
 		// resolving it. we rely on the rewriting that will happen inside heap
 		// domain to translate this into a variable that will have its correct
 		// type
-		return computedState.smallStepSemantics(new AccessChild(getRuntimeTypes(), left, right));
+		return rightState.smallStepSemantics(new AccessChild(getRuntimeTypes(), left, right));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPArrayAccess.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPArrayAccess.java
@@ -36,6 +36,7 @@ public class IMPArrayAccess extends BinaryNativeCall {
 		super(cfg, sourceFile, line, col, "[]", container, location);
 	}
 
+	@Override
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPDiv.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPDiv.java
@@ -42,16 +42,20 @@ public class IMPDiv extends BinaryNativeCall implements BinaryNumericalOperation
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(commonNumericalType(left, right), left, right,
 						BinaryOperator.NUMERIC_DIV));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPEqual.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPEqual.java
@@ -41,10 +41,14 @@ public class IMPEqual extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_EQ));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPFieldAccess.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPFieldAccess.java
@@ -39,15 +39,19 @@ public class IMPFieldAccess extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		if (!left.getDynamicType().isPointerType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		// it is not possible to detect the correct type of the field without
 		// resolving it. we rely on the rewriting that will happen inside heap
 		// domain to translate this into a variable that will have its correct
 		// type
-		return computedState.smallStepSemantics(new AccessChild(getRuntimeTypes(), left, right));
+		return rightState.smallStepSemantics(new AccessChild(getRuntimeTypes(), left, right));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterOrEqual.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterOrEqual.java
@@ -43,16 +43,20 @@ public class IMPGreaterOrEqual extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_GE));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterThan.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterThan.java
@@ -39,6 +39,7 @@ public class IMPGreaterThan extends BinaryNativeCall {
 		super(cfg, sourceFile, line, col, ">", BoolType.INSTANCE, left, right);
 	}
 
+	@Override
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterThan.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPGreaterThan.java
@@ -39,20 +39,23 @@ public class IMPGreaterThan extends BinaryNativeCall {
 		super(cfg, sourceFile, line, col, ">", BoolType.INSTANCE, left, right);
 	}
 
-	@Override
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_GT));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPLessOrEqual.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPLessOrEqual.java
@@ -43,16 +43,20 @@ public class IMPLessOrEqual extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_LE));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPLessThan.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPLessThan.java
@@ -43,16 +43,19 @@ public class IMPLessThan extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_LT));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPMod.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPMod.java
@@ -42,16 +42,19 @@ public class IMPMod extends BinaryNativeCall implements BinaryNumericalOperation
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(commonNumericalType(left, right), left, right,
 						BinaryOperator.NUMERIC_MOD));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPMul.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPMul.java
@@ -42,16 +42,19 @@ public class IMPMul extends BinaryNativeCall implements BinaryNumericalOperation
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(commonNumericalType(left, right), left, right,
 						BinaryOperator.NUMERIC_MUL));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNeg.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNeg.java
@@ -40,12 +40,13 @@ public class IMPNeg extends UnaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression expr)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V> exprState,
+					SymbolicExpression expr)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!expr.getDynamicType().isNumericType() && !expr.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState.smallStepSemantics(new UnaryExpression(expr.getTypes(), expr, UnaryOperator.NUMERIC_NEG));
+		return exprState.smallStepSemantics(new UnaryExpression(expr.getTypes(), expr, UnaryOperator.NUMERIC_NEG));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNewArray.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNewArray.java
@@ -45,16 +45,28 @@ public class IMPNewArray extends NativeCall {
 	public <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> callSemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, Collection<SymbolicExpression>[] params)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V>[] computedStates,
+					Collection<SymbolicExpression>[] params)
 					throws SemanticException {
-		return computedState.smallStepSemantics(new HeapAllocation(getRuntimeTypes()));
+		// it corresponds to the analysis state after the evaluation of all the
+		// parameters of this call
+		// (the semantics of this call does not need information about the
+		// intermediate analysis states)
+		AnalysisState<A, H, V> lastPostState = computedStates[computedStates.length - 1];
+		return lastPostState.smallStepSemantics(new HeapAllocation(getRuntimeTypes()));
 	}
 
 	@Override
 	public <A extends AbstractState<A, H, TypeEnvironment>,
 			H extends HeapDomain<H>> AnalysisState<A, H, TypeEnvironment> callTypeInference(
-					AnalysisState<A, H, TypeEnvironment> computedState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment> entryState, CallGraph callGraph,
+					AnalysisState<A, H, TypeEnvironment>[] computedStates,
 					Collection<SymbolicExpression>[] params) throws SemanticException {
-		return computedState.smallStepSemantics(new HeapAllocation(Caches.types().mkSingletonSet(getStaticType())));
+		// it corresponds to the analysis state after the evaluation of all the
+		// parameters of this call
+		// (the semantics of this call does not need information about the
+		// intermediate analysis states)
+		AnalysisState<A, H, TypeEnvironment> lastPostState = computedStates[computedStates.length - 1];
+		return lastPostState.smallStepSemantics(new HeapAllocation(Caches.types().mkSingletonSet(getStaticType())));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNot.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNot.java
@@ -42,13 +42,14 @@ public class IMPNot extends UnaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression expr)
+					AnalysisState<A, H, V> entryState, CallGraph callGraph, AnalysisState<A, H, V> exprState,
+					SymbolicExpression expr)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!expr.getDynamicType().isBooleanType() && !expr.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState.smallStepSemantics(
+		return exprState.smallStepSemantics(
 				new UnaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), expr, UnaryOperator.LOGICAL_NOT));
 	}
 }

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNotEqual.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPNotEqual.java
@@ -41,10 +41,13 @@ public class IMPNotEqual extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
 					throws SemanticException {
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.COMPARISON_NE));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPOr.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPOr.java
@@ -43,16 +43,19 @@ public class IMPOr extends BinaryNativeCall {
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isBooleanType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isBooleanType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(Caches.types().mkSingletonSet(BoolType.INSTANCE), left, right,
 						BinaryOperator.LOGICAL_OR));
 	}

--- a/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPSub.java
+++ b/lisa/src/test/java/it/unive/lisa/test/imp/expressions/IMPSub.java
@@ -42,16 +42,20 @@ public class IMPSub extends BinaryNativeCall implements BinaryNumericalOperation
 	protected <A extends AbstractState<A, H, V>,
 			H extends HeapDomain<H>,
 			V extends ValueDomain<V>> AnalysisState<A, H, V> binarySemantics(
-					AnalysisState<A, H, V> computedState, CallGraph callGraph, SymbolicExpression left,
+					AnalysisState<A, H, V> entryState, CallGraph callGraph,
+					AnalysisState<A, H, V> leftState,
+					SymbolicExpression left,
+					AnalysisState<A, H, V> rightState,
 					SymbolicExpression right)
+
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 		if (!right.getDynamicType().isNumericType() && !right.getDynamicType().isUntyped())
-			return computedState.bottom();
+			return entryState.bottom();
 
-		return computedState
+		return rightState
 				.smallStepSemantics(new BinaryExpression(commonNumericalType(left, right), left, right,
 						BinaryOperator.NUMERIC_SUB));
 	}


### PR DESCRIPTION
**Description**
The ```callSemantics``` and ```callTypeInference``` methods in ```Call``` were chaining left-to-right the evaluation of their parameters in a single ```AnalysisState```. Chaining the parameters evaluation in a single analysis state is limiting when we need to deal with the intermediate analysis states obtained by the evaluation of the parameters (for example with short-circuit logics). In this pull request, the parameters evaluation is still chained (and left-to-right) but tracking each obtained intermediate analysis state.