### PR TITLE
Reasoning about type cast and type conversion expressions for base non relational value domain

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/types/InferredTypes.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/types/InferredTypes.java
@@ -13,6 +13,7 @@ import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.symbolic.types.BoolType;
 import it.unive.lisa.symbolic.types.IntType;
 import it.unive.lisa.symbolic.types.StringType;
+import it.unive.lisa.symbolic.value.BinaryExpression;
 import it.unive.lisa.symbolic.value.BinaryOperator;
 import it.unive.lisa.symbolic.value.Constant;
 import it.unive.lisa.symbolic.value.Identifier;
@@ -203,20 +204,9 @@ public class InferredTypes extends BaseInferredValue<InferredTypes> {
 				return bottom();
 			return new InferredTypes(BoolType.INSTANCE);
 		case TYPE_CAST:
-			if (right.elements.noneMatch(Type::isTypeTokenType))
-				return bottom();
-			set = cast(left.elements, right.elements);
-			if (set.isEmpty())
-				return bottom();
-			return new InferredTypes(set);
+			return evalTypeCast(null, left, right);
 		case TYPE_CONV:
-			if (right.elements.noneMatch(Type::isTypeTokenType))
-				return bottom();
-			set = convert(left.elements, right.elements);
-			if (set.isEmpty())
-				return bottom();
-			return new InferredTypes(set);
-
+			return evalTypeConv(null, left, right);
 		case TYPE_CHECK:
 			if (right.elements.noneMatch(Type::isTypeTokenType))
 				return bottom();
@@ -438,6 +428,26 @@ public class InferredTypes extends BaseInferredValue<InferredTypes> {
 					result.add(t1.commonSupertype(t2));
 
 		return result;
+	}
+
+	@Override
+	protected InferredTypes evalTypeCast(BinaryExpression cast, InferredTypes left, InferredTypes right) {
+		if (right.elements.noneMatch(Type::isTypeTokenType))
+			return bottom();
+		ExternalSet<Type> set = cast(left.elements, right.elements);
+		if (set.isEmpty())
+			return bottom();
+		return new InferredTypes(set);
+	}
+
+	@Override
+	protected InferredTypes evalTypeConv(BinaryExpression conv, InferredTypes left, InferredTypes right) {
+		if (right.elements.noneMatch(Type::isTypeTokenType))
+			return bottom();
+		ExternalSet<Type> set = convert(left.elements, right.elements);
+		if (set.isEmpty())
+			return bottom();
+		return new InferredTypes(set);
 	}
 
 	@Override

--- a/lisa/src/main/java/it/unive/lisa/analysis/inference/BaseInferredValue.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/inference/BaseInferredValue.java
@@ -141,6 +141,12 @@ public abstract class BaseInferredValue<T extends BaseInferredValue<T>> extends 
 			if (right.isBottom())
 				return right;
 
+			if (binary.getOperator() == BinaryOperator.TYPE_CAST)
+				return evalTypeCast(binary, left, right);
+
+			if (binary.getOperator() == BinaryOperator.TYPE_CONV)
+				return evalTypeConv(binary, left, right);
+
 			return evalBinaryExpression(binary.getOperator(), left, right, pp);
 		}
 
@@ -233,7 +239,9 @@ public abstract class BaseInferredValue<T extends BaseInferredValue<T>> extends 
 	 * Yields the evaluation of a {@link BinaryExpression} applying
 	 * {@code operator} to two expressions whose abstract value are {@code left}
 	 * and {@code right}, respectively. It is guaranteed that both {@code left}
-	 * and {@code right} are not {@link #bottom()}.
+	 * and {@code right} are not {@link #bottom()} and that {@code operator} is
+	 * neither {@link BinaryOperator#TYPE_CAST} nor
+	 * {@link BinaryOperator#TYPE_CONV}.
 	 * 
 	 * @param operator the operator applied by the expression
 	 * @param left     the instance of this domain representing the abstract
@@ -247,6 +255,34 @@ public abstract class BaseInferredValue<T extends BaseInferredValue<T>> extends 
 	 */
 	protected T evalBinaryExpression(BinaryOperator operator, T left, T right, ProgramPoint pp) {
 		return top();
+	}
+
+	/**
+	 * Yields the evaluation of a type conversion expression.
+	 * 
+	 * @param conv  the type conversion expression
+	 * @param left  the left expression, namely the expression to be converted
+	 * @param right the right expression, namely the types to which left should
+	 *                  be converted
+	 * 
+	 * @return the evaluation of the type conversion expression
+	 */
+	protected T evalTypeConv(BinaryExpression conv, T left, T right) {
+		return conv.getTypes().isEmpty() ? bottom() : left;
+	}
+
+	/**
+	 * Yields the evaluation of a type cast expression.
+	 * 
+	 * @param cast  the type casted expression
+	 * @param left  the left expression, namely the expression to be casted
+	 * @param right the right expression, namely the types to which left should
+	 *                  be casted
+	 * 
+	 * @return the evaluation of the type cast expression
+	 */
+	protected T evalTypeCast(BinaryExpression cast, T left, T right) {
+		return cast.getTypes().isEmpty() ? bottom() : left;
 	}
 
 	/**

--- a/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
@@ -28,7 +28,7 @@ import it.unive.lisa.symbolic.value.ValueExpression;
  * @param <T> the concrete type of this domain
  */
 public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalValueDomain<T>> extends BaseLattice<T>
-		implements NonRelationalValueDomain<T> {
+implements NonRelationalValueDomain<T> {
 
 	@Override
 	public final Satisfiability satisfies(ValueExpression expression, ValueEnvironment<T> environment,
@@ -134,7 +134,7 @@ public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalVa
 
 		if (expression instanceof BinaryExpression) {
 			BinaryExpression binary = (BinaryExpression) expression;
-
+			
 			T left = eval((ValueExpression) binary.getLeft(), environment, pp);
 			if (left.isBottom())
 				return left;
@@ -142,6 +142,12 @@ public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalVa
 			T right = eval((ValueExpression) binary.getRight(), environment, pp);
 			if (right.isBottom())
 				return right;
+			
+			if (binary.getOperator() == BinaryOperator.TYPE_CAST)
+				return evalTypeCast(binary, left, right);
+			
+			if (binary.getOperator() == BinaryOperator.TYPE_CONV)
+				return evalTypeConv(binary, left, right);
 
 			return evalBinaryExpression(binary.getOperator(), left, right, pp);
 		}
@@ -177,6 +183,30 @@ public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalVa
 	@Override
 	public boolean canProcess(SymbolicExpression expression) {
 		return !expression.getDynamicType().isPointerType();
+	}
+	
+	/**
+	 * Yields the evaluation of a type conversion expression.
+	 * 
+	 * @param conv the type conversion expression
+	 * @param left the left expression, namely the expression to be converted
+	 * @param right the right expression, namely the types to which left should be converted
+	 * @return the evaluation of the type conversion expression
+	 */
+	protected T evalTypeConv(BinaryExpression conv, T left, T right) {
+		return conv.getTypes().isEmpty() ? bottom() : left;
+	}
+	
+	/**
+	 * Yields the evaluation of a type cast expression.
+	 * 
+	 * @param cast the type csated expression
+	 * @param left the left expression, namely the expression to be casted
+	 * @param right the right expression, namely the types to which left should be casted
+	 * @return the evaluation of the type cast expression
+	 */
+	protected T evalTypeCast(BinaryExpression cast, T left, T right) {
+		return cast.getTypes().isEmpty() ? bottom() : left;
 	}
 
 	/**

--- a/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
@@ -28,7 +28,7 @@ import it.unive.lisa.symbolic.value.ValueExpression;
  * @param <T> the concrete type of this domain
  */
 public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalValueDomain<T>> extends BaseLattice<T>
-implements NonRelationalValueDomain<T> {
+		implements NonRelationalValueDomain<T> {
 
 	@Override
 	public final Satisfiability satisfies(ValueExpression expression, ValueEnvironment<T> environment,
@@ -134,7 +134,7 @@ implements NonRelationalValueDomain<T> {
 
 		if (expression instanceof BinaryExpression) {
 			BinaryExpression binary = (BinaryExpression) expression;
-			
+
 			T left = eval((ValueExpression) binary.getLeft(), environment, pp);
 			if (left.isBottom())
 				return left;
@@ -142,10 +142,10 @@ implements NonRelationalValueDomain<T> {
 			T right = eval((ValueExpression) binary.getRight(), environment, pp);
 			if (right.isBottom())
 				return right;
-			
+
 			if (binary.getOperator() == BinaryOperator.TYPE_CAST)
 				return evalTypeCast(binary, left, right);
-			
+
 			if (binary.getOperator() == BinaryOperator.TYPE_CONV)
 				return evalTypeConv(binary, left, right);
 
@@ -184,25 +184,29 @@ implements NonRelationalValueDomain<T> {
 	public boolean canProcess(SymbolicExpression expression) {
 		return !expression.getDynamicType().isPointerType();
 	}
-	
+
 	/**
 	 * Yields the evaluation of a type conversion expression.
 	 * 
-	 * @param conv the type conversion expression
-	 * @param left the left expression, namely the expression to be converted
-	 * @param right the right expression, namely the types to which left should be converted
+	 * @param conv  the type conversion expression
+	 * @param left  the left expression, namely the expression to be converted
+	 * @param right the right expression, namely the types to which left should
+	 *                  be converted
+	 * 
 	 * @return the evaluation of the type conversion expression
 	 */
 	protected T evalTypeConv(BinaryExpression conv, T left, T right) {
 		return conv.getTypes().isEmpty() ? bottom() : left;
 	}
-	
+
 	/**
 	 * Yields the evaluation of a type cast expression.
 	 * 
-	 * @param cast the type csated expression
-	 * @param left the left expression, namely the expression to be casted
-	 * @param right the right expression, namely the types to which left should be casted
+	 * @param cast  the type csated expression
+	 * @param left  the left expression, namely the expression to be casted
+	 * @param right the right expression, namely the types to which left should
+	 *                  be casted
+	 * 
 	 * @return the evaluation of the type cast expression
 	 */
 	protected T evalTypeCast(BinaryExpression cast, T left, T right) {

--- a/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/nonrelational/value/BaseNonRelationalValueDomain.java
@@ -202,7 +202,7 @@ public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalVa
 	/**
 	 * Yields the evaluation of a type cast expression.
 	 * 
-	 * @param cast  the type csated expression
+	 * @param cast  the type casted expression
 	 * @param left  the left expression, namely the expression to be casted
 	 * @param right the right expression, namely the types to which left should
 	 *                  be casted
@@ -258,7 +258,9 @@ public abstract class BaseNonRelationalValueDomain<T extends BaseNonRelationalVa
 	 * Yields the evaluation of a {@link BinaryExpression} applying
 	 * {@code operator} to two expressions whose abstract value are {@code left}
 	 * and {@code right}, respectively. It is guaranteed that both {@code left}
-	 * and {@code right} are not {@link #bottom()}.
+	 * and {@code right} are not {@link #bottom()} and that {@code operator} is
+	 * neither {@link BinaryOperator#TYPE_CAST} nor
+	 * {@link BinaryOperator#TYPE_CONV}.
 	 * 
 	 * @param operator the operator applied by the expression
 	 * @param left     the instance of this domain representing the abstract


### PR DESCRIPTION
With this pull request, base non relational value domains are able to reason about type cast and type conversion expressions. In particular, the default implementation in the class ```BaseNonRelationalValueDomain``` relies on the analysis results obtained by the type analysis: if it is able to type the aforementioned symbolic expressions (i.e., when the set of types of the expression is not empty) , then the value is returned, otherwise (i.e., when the set of types of the expression is empty) bottom is returned.

Closes #55 