### PR TITLE
Equals and hashCode methods for set-based lattice implementations and FunctionalLattice

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/analysis/dataflow/DefiniteForwardDataflowDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/dataflow/DefiniteForwardDataflowDomain.java
@@ -102,7 +102,7 @@ public class DefiniteForwardDataflowDomain<E extends DataflowElement<DefiniteFor
 		elements.stream().map(e -> e.toString()).forEach(res::add);
 		return res.toString();
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;

--- a/lisa/src/main/java/it/unive/lisa/analysis/dataflow/DefiniteForwardDataflowDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/dataflow/DefiniteForwardDataflowDomain.java
@@ -102,6 +102,29 @@ public class DefiniteForwardDataflowDomain<E extends DataflowElement<DefiniteFor
 		elements.stream().map(e -> e.toString()).forEach(res::add);
 		return res.toString();
 	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (isTop ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DefiniteForwardDataflowDomain<E> other = (DefiniteForwardDataflowDomain<E>) obj;
+		if (isTop != other.isTop)
+			return false;
+		return true;
+	}
 
 	@Override
 	public DefiniteForwardDataflowDomain<E> top() {

--- a/lisa/src/main/java/it/unive/lisa/analysis/dataflow/PossibleForwardDataflowDomain.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/dataflow/PossibleForwardDataflowDomain.java
@@ -95,6 +95,29 @@ public class PossibleForwardDataflowDomain<E extends DataflowElement<PossibleFor
 	}
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (isTop ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PossibleForwardDataflowDomain<E> other = (PossibleForwardDataflowDomain<E>) obj;
+		if (isTop != other.isTop)
+			return false;
+		return true;
+	}
+
+	@Override
 	public String representation() {
 		SortedSet<String> res = new TreeSet<>();
 		elements.stream().map(e -> e.toString()).forEach(res::add);

--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/heap/pointbased/AllocationSites.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/heap/pointbased/AllocationSites.java
@@ -88,6 +88,28 @@ public class AllocationSites extends SetLattice<AllocationSites, AllocationSite>
 	}
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (isTop ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AllocationSites other = (AllocationSites) obj;
+		if (isTop != other.isTop)
+			return false;
+		return true;
+	}
+
+	@Override
 	public String representation() {
 		return super.toString();
 	}

--- a/lisa/src/main/java/it/unive/lisa/analysis/lattices/ExpressionSet.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/lattices/ExpressionSet.java
@@ -83,6 +83,29 @@ public class ExpressionSet<T extends SymbolicExpression> extends SetLattice<Expr
 	}
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (isTop ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ExpressionSet<T> other = (ExpressionSet<T>) obj;
+		if (isTop != other.isTop)
+			return false;
+		return true;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	protected ExpressionSet<T> lubAux(ExpressionSet<T> other) throws SemanticException {
 		Set<T> lub = new HashSet<>();

--- a/lisa/src/main/java/it/unive/lisa/analysis/lattices/FunctionalLattice.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/lattices/FunctionalLattice.java
@@ -229,10 +229,7 @@ public abstract class FunctionalLattice<F extends FunctionalLattice<F, K, V>, K,
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((function == null) ? 0 : function.hashCode());
-		// we use the name of the lattice's class since we do not care about the
-		// single
-		// instance, but more about the type itself
-		result = prime * result + ((lattice == null) ? 0 : lattice.getClass().getName().hashCode());
+		result = prime * result + ((lattice == null) ? 0 : lattice.hashCode());
 		return result;
 	}
 
@@ -253,9 +250,7 @@ public abstract class FunctionalLattice<F extends FunctionalLattice<F, K, V>, K,
 		if (lattice == null) {
 			if (other.lattice != null)
 				return false;
-		} else if (lattice.getClass() != other.lattice.getClass())
-			// we use the lattice's class since we do not care about the single
-			// instance, but more about the type itself
+		} else if (!lattice.equals(other.lattice))
 			return false;
 		return true;
 	}


### PR DESCRIPTION
**Description**
Minor fixes to ```equals``` and ```hashCode``` methods for ```FunctionalLattice``` and set-based lattice concrete implementations.

**Fixed bugs**
Closes #76 
Closes #75 
