### PR TITLE
Interval greatest lower bound fixes

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
@@ -47,6 +47,12 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		this.isBottom = isBottom;
 	}
 
+	/**
+	 * Builds an interval from its low bound and high bound.
+	 * 
+	 * @param low  the low bound
+	 * @param high the high bound
+	 */
 	public Interval(Integer low, Integer high) {
 		this(low, high, false, false);
 	}
@@ -72,11 +78,21 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 	public Interval bottom() {
 		return BOTTOM;
 	}
-	
+
+	/**
+	 * Yields the high bound of this interval.
+	 * 
+	 * @return the high bound of this interval.
+	 */
 	public Integer getHigh() {
 		return high;
 	}
-	
+
+	/**
+	 * Yields the low bound of this interval.
+	 * 
+	 * @return the low bound of this interval.
+	 */
 	public Integer getLow() {
 		return low;
 	}
@@ -182,7 +198,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		Integer newLow = lowIsMinusInfinity() ? other.low : other.lowIsMinusInfinity() ? low : Math.max(low, other.low);
 		Integer newHigh = highIsPlusInfinity() ? other.high
 				: other.highIsPlusInfinity() ? high : Math.min(high, other.high);
-		
+
 		if (newLow != null && newHigh != null && newLow > newHigh)
 			return bottom();
 		return new Interval(newLow, newHigh);

--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
@@ -47,7 +47,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		this.isBottom = isBottom;
 	}
 
-	private Interval(Integer low, Integer high) {
+	public Interval(Integer low, Integer high) {
 		this(low, high, false, false);
 	}
 
@@ -71,6 +71,14 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 	@Override
 	public Interval bottom() {
 		return BOTTOM;
+	}
+	
+	public Integer getHigh() {
+		return high;
+	}
+	
+	public Integer getLow() {
+		return low;
 	}
 
 	@Override
@@ -174,6 +182,9 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		Integer newLow = lowIsMinusInfinity() ? other.low : other.lowIsMinusInfinity() ? low : Math.max(low, other.low);
 		Integer newHigh = highIsPlusInfinity() ? other.high
 				: other.highIsPlusInfinity() ? high : Math.min(high, other.high);
+		
+		if (newLow != null && newHigh != null && newLow > newHigh)
+			return bottom();
 		return new Interval(newLow, newHigh);
 	}
 


### PR DESCRIPTION
**Description**
Interval greatest lower bound now correctly works when the intersection of the interval values is empty (e.g., [0,0] glb with [1,1] returns bottom).

**Fixed bugs**
Closes #78
