### PR TITLE
Interval satisfies method

### DIFF
--- a/lisa/imp-testcases/interval/analysis___untyped_tutorial.sat(tutorial_this,_untyped_x,_untyped_y).dot
+++ b/lisa/imp-testcases/interval/analysis___untyped_tutorial.sat(tutorial_this,_untyped_x,_untyped_y).dot
@@ -1,0 +1,38 @@
+digraph {
+	"node0" [shape="rect",color="black",label=<i = -1<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-1, -1]<BR/>x: #TOP#<BR/>y: #TOP# ]]<BR/>}} -&gt; [i]>];
+	"node1" [shape="rect",color="gray",label=<x = +(x, 1)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [2, 2]<BR/>y: #TOP# ]]<BR/>}} -&gt; [x]>];
+	"node2" [shape="rect",color="gray",label=<&lt;=(i, -1)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [1, 1]<BR/>y: #TOP# ]]<BR/>}} -&gt; [i &lt;= -1]>];
+	"node3" [shape="rect",color="gray",label=<i = -(i, 1)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -2]<BR/>j: [0, +Inf]<BR/>x: #TOP#<BR/>y: #TOP# ]]<BR/>}} -&gt; [i]>];
+	"node4" [shape="rect",color="gray",label=<==(x, y)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: #TOP#<BR/>y: #TOP# ]]<BR/>}} -&gt; [x == y]>];
+	"node5" [shape="rect",color="gray",label=<&lt;(i, j)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [0, 0]<BR/>y: #TOP# ]]<BR/>}} -&gt; [i &lt; j]>];
+	"node6" [shape="rect",color="gray",label=<&gt;=(j, 5)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [2, 2]<BR/>y: #TOP# ]]<BR/>}} -&gt; [j &gt;= 5]>];
+	"node7" [shape="rect",color="gray",label=<x = 0<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [0, 0]<BR/>y: #TOP# ]]<BR/>}} -&gt; [x]>];
+	"node8" [shape="rect",color="gray",label=<j = +(j, 1)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -2]<BR/>j: [1, +Inf]<BR/>x: #TOP#<BR/>y: #TOP# ]]<BR/>}} -&gt; [j]>];
+	"node9" [shape="rect",color="gray",label=<j = 0<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-1, -1]<BR/>j: [0, 0]<BR/>x: #TOP#<BR/>y: #TOP# ]]<BR/>}} -&gt; [j]>];
+	"node10" [shape="rect",color="gray",label=<x = 1<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>x: [1, 1]<BR/>y: #TOP# ]]<BR/>}} -&gt; [x]>];
+	"node11" [shape="rect",color="black",peripheries="2",label=<return x<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [0, +Inf]<BR/>ret_value@sat: [2, 3]<BR/>x: [2, 3]<BR/>y: #TOP# ]]<BR/>}} -&gt; [ret_value@sat]>];
+	"node12" [shape="rect",color="gray",label=<x = +(x, 1)<BR/>{{<BR/>heap [[ monolith ]]<BR/>value [[ i: [-Inf, -1]<BR/>j: [5, +Inf]<BR/>x: [3, 3]<BR/>y: #TOP# ]]<BR/>}} -&gt; [x]>];
+	"node1" -> "node6" [color="black"];
+	"node2" -> "node6" [color="red",style="dashed"];
+	"node2" -> "node1" [color="blue",style="dashed"];
+	"node3" -> "node8" [color="black"];
+	"node4" -> "node7" [color="red",style="dashed"];
+	"node4" -> "node3" [color="blue",style="dashed"];
+	"node0" -> "node9" [color="black"];
+	"node5" -> "node2" [color="red",style="dashed"];
+	"node5" -> "node10" [color="blue",style="dashed"];
+	"node6" -> "node11" [color="red",style="dashed"];
+	"node6" -> "node12" [color="blue",style="dashed"];
+	"node7" -> "node5" [color="black"];
+	"node8" -> "node4" [color="black"];
+	"node9" -> "node4" [color="black"];
+	"node10" -> "node2" [color="black"];
+	"node12" -> "node11" [color="black"];
+subgraph cluster_legend {
+	label="Legend";
+	style=dotted;
+	node [shape=plaintext];
+	"legend" [label=<<table border="0" cellpadding="2" cellspacing="0" cellborder="0"><tr><td align="right">node border&nbsp;</td><td align="left"><font color="gray">gray</font>, single</td></tr><tr><td align="right">entrypoint border&nbsp;</td><td align="left"><font color="black">black</font>, single</td></tr><tr><td align="right">exitpoint border&nbsp;</td><td align="left"><font color="black">black</font>, double</td></tr><tr><td align="right">sequential edge&nbsp;</td><td align="left"><font color="black">black</font>, solid</td></tr><tr><td align="right">true edge&nbsp;</td><td align="left"><font color="blue">blue</font>, dashed</td></tr><tr><td align="right">false edge&nbsp;</td><td align="left"><font color="red">red</font>, dashed</td></tr></table>>];
+}
+
+}

--- a/lisa/imp-testcases/interval/program.imp
+++ b/lisa/imp-testcases/interval/program.imp
@@ -58,4 +58,25 @@ class tutorial {
 		
 		return x;
 	}
+	
+	sat(x,y) { 
+		def i = -1;
+		def j = 0;
+		
+		while (x == y) {
+			i = i - 1;
+			j = j + 1;
+		}
+		x = 0;
+		if (i < j) // sat
+			x = 1;
+			
+		if (i <= -1) // sat
+			x = x + 1;
+			
+		if (j >= 5) // unknown
+			x = x + 1;
+			
+		return x; // expected x = [2,3]
+	}	
 }

--- a/lisa/imp-testcases/interval/report.json
+++ b/lisa/imp-testcases/interval/report.json
@@ -1,4 +1,4 @@
 {
   "warnings" : [ ],
-  "files" : [ "analysis___untyped_tutorial.constants(tutorial_this).dot", "analysis___untyped_tutorial.div(tutorial_this,_untyped_i,_untyped_j).dot", "analysis___untyped_tutorial.gcd(tutorial_this,_untyped_a,_untyped_b).dot", "analysis___untyped_tutorial.glb(tutorial_this,_untyped_x,_untyped_y).dot", "analysis___untyped_tutorial.intv_dec(tutorial_this).dot", "analysis___untyped_tutorial.sign_parity_example(tutorial_this).dot", "analysis___untyped_tutorial.ub_example(tutorial_this,_untyped_y,_untyped_z).dot" ]
+  "files" : [ "analysis___untyped_tutorial.constants(tutorial_this).dot", "analysis___untyped_tutorial.div(tutorial_this,_untyped_i,_untyped_j).dot", "analysis___untyped_tutorial.gcd(tutorial_this,_untyped_a,_untyped_b).dot", "analysis___untyped_tutorial.glb(tutorial_this,_untyped_x,_untyped_y).dot", "analysis___untyped_tutorial.intv_dec(tutorial_this).dot", "analysis___untyped_tutorial.sat(tutorial_this,_untyped_x,_untyped_y).dot", "analysis___untyped_tutorial.sign_parity_example(tutorial_this).dot", "analysis___untyped_tutorial.ub_example(tutorial_this,_untyped_y,_untyped_z).dot" ]
 }

--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
@@ -346,14 +346,14 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		if (left.isTop() || right.isTop())
 			return Satisfiability.UNKNOWN;
 
-		Interval glb = null;
-		try {
-			glb = left.glb(right);
-		} catch (SemanticException e) {
-			e.printStackTrace();
-		}
 		switch (operator) {
 		case COMPARISON_EQ:
+			Interval glb = null;
+			try {
+				glb = left.glb(right);
+			} catch (SemanticException e) {
+				e.printStackTrace();
+			}
 			if (glb.isBottom())
 				return Satisfiability.NOT_SATISFIED;
 			else if (left.isSingleton() && left.equals(right))
@@ -403,6 +403,12 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				return Satisfiability.SATISFIED;
 			return Satisfiability.UNKNOWN;
 		case COMPARISON_NE:
+			glb = null;
+			try {
+				glb = left.glb(right);
+			} catch (SemanticException e) {
+				e.printStackTrace();
+			}
 			if (glb.isBottom())
 				return Satisfiability.SATISFIED;
 			return Satisfiability.UNKNOWN;

--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/numeric/Interval.java
@@ -2,8 +2,8 @@ package it.unive.lisa.analysis.impl.numeric;
 
 import it.unive.lisa.analysis.BaseLattice;
 import it.unive.lisa.analysis.Lattice;
-import it.unive.lisa.analysis.SemanticException;
 import it.unive.lisa.analysis.SemanticDomain.Satisfiability;
+import it.unive.lisa.analysis.SemanticException;
 import it.unive.lisa.analysis.nonrelational.value.BaseNonRelationalValueDomain;
 import it.unive.lisa.analysis.nonrelational.value.ValueEnvironment;
 import it.unive.lisa.program.cfg.ProgramPoint;
@@ -33,36 +33,38 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class Interval extends BaseNonRelationalValueDomain<Interval> {
 
-	private static final Interval TOP = new Interval(null, null, true, false);
-	private static final Interval BOTTOM = new Interval(null, null, false, true);
+	private static final Interval TOP = new Interval(null, null, true);
+	private static final Interval BOTTOM = new Interval(null, null, false);
 
-	private final boolean isTop, isBottom;
+	private final boolean isTop;
 
 	private final Integer low;
 	private final Integer high;
 
-	private Interval(Integer low, Integer high, boolean isTop, boolean isBottom) {
+	private Interval(Integer low, Integer high, boolean isTop) {
 		this.low = low;
 		this.high = high;
 		this.isTop = isTop;
-		this.isBottom = isBottom;
 	}
 
 	/**
-	 * Builds an interval from its low bound and high bound.
+	 * Builds an interval from its low bound and high bound. Call this
+	 * constructor iff {@code low} and {@code high} are not both null. If you
+	 * need to build top or bottom elements, call {@link Interval#top()} and
+	 * {@link Interval#bottom()}, respectively.
 	 * 
 	 * @param low  the low bound
 	 * @param high the high bound
 	 */
 	public Interval(Integer low, Integer high) {
-		this(low, high, false, false);
+		this(low, high, false);
 	}
 
 	/**
 	 * Builds the top interval.
 	 */
 	public Interval() {
-		this(null, null, true, false);
+		this(null, null, true);
 	}
 
 	@Override
@@ -72,12 +74,17 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 
 	@Override
 	public boolean isTop() {
-		return isTop;
+		return isTop && low == null && low == high;
 	}
 
 	@Override
 	public Interval bottom() {
 		return BOTTOM;
+	}
+
+	@Override
+	public boolean isBottom() {
+		return !isTop && low == null && low == high;
 	}
 
 	/**
@@ -191,7 +198,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 	protected Interval lubAux(Interval other) throws SemanticException {
 		Integer newLow = lowIsMinusInfinity() || other.lowIsMinusInfinity() ? null : Math.min(low, other.low);
 		Integer newHigh = highIsPlusInfinity() || other.highIsPlusInfinity() ? null : Math.max(high, other.high);
-		return new Interval(newLow, newHigh);
+		return newLow == null && newLow == newHigh ? top() : new Interval(newLow, newHigh);
 	}
 
 	@Override
@@ -202,7 +209,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 
 		if (newLow != null && newHigh != null && newLow > newHigh)
 			return bottom();
-		return new Interval(newLow, newHigh);
+		return newLow == null && newLow == newHigh ? top() : new Interval(newLow, newHigh);
 	}
 
 	@Override
@@ -218,7 +225,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		else
 			newLow = other.low;
 
-		return new Interval(newLow, newHigh);
+		return newLow == null && newLow == newHigh ? top() : new Interval(newLow, newHigh);
 	}
 
 	@Override
@@ -247,7 +254,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		else
 			newHigh = high + other.high;
 
-		return new Interval(newLow, newHigh);
+		return newLow == null && newLow == newHigh ? top() : new Interval(newLow, newHigh);
 	}
 
 	private Interval diff(Interval other) {
@@ -263,7 +270,7 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		else
 			newHigh = high - other.low;
 
-		return new Interval(newLow, newHigh);
+		return newLow == null && newLow == newHigh ? top() : new Interval(newLow, newHigh);
 	}
 
 	private Interval mul(Interval other) {
@@ -290,7 +297,11 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		// x2 * y2
 		multiplyBounds(boundSet, h1, h2, lowInf, highInf);
 
-		return new Interval(lowInf.get() ? null : boundSet.first(), highInf.get() ? null : boundSet.last());
+		Interval result = new Interval(lowInf.get() ? null : boundSet.first(), highInf.get() ? null : boundSet.last());
+		if (result.low == null && result.high == result.low)
+			return top();
+		else
+			return result;
 	}
 
 	private Interval div(Interval other) {
@@ -317,7 +328,11 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		// x2 / y2
 		divideBounds(boundSet, h1, h2, lowInf, highInf);
 
-		return new Interval(lowInf.get() ? null : boundSet.first(), highInf.get() ? null : boundSet.last());
+		Interval result = new Interval(lowInf.get() ? null : boundSet.first(), highInf.get() ? null : boundSet.last());
+		if (result.low == null && result.high == result.low)
+			return top();
+		else
+			return result;
 	}
 
 	private boolean isSingleton() {
@@ -327,20 +342,20 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 	@Override
 	protected Satisfiability satisfiesBinaryExpression(BinaryOperator operator, Interval left, Interval right,
 			ProgramPoint pp) {
-		
+
 		if (left.isTop() || right.isTop())
 			return Satisfiability.UNKNOWN;
-		
+
 		Interval glb = null;
 		try {
 			glb = left.glb(right);
 		} catch (SemanticException e) {
 			e.printStackTrace();
 		}
-		switch(operator) {
+		switch (operator) {
 		case COMPARISON_EQ:
 			if (glb.isBottom())
-				return Satisfiability.NOT_SATISFIED;	
+				return Satisfiability.NOT_SATISFIED;
 			else if (left.isSingleton() && left.equals(right))
 				return Satisfiability.SATISFIED;
 			return Satisfiability.UNKNOWN;
@@ -349,8 +364,8 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		case COMPARISON_GT:
 			return satisfiesBinaryExpression(BinaryOperator.COMPARISON_LT, right, left, pp);
 		case COMPARISON_LE:
-			Interval firstBound = new Interval(null, right.high);
-			Interval secondBound = new Interval(left.low, null);
+			Interval firstBound = right.high == null ? top() : new Interval(null, right.high);
+			Interval secondBound = left.low == null ? top() : new Interval(left.low, null);
 
 			Interval firstCheck = null;
 			Interval secondCheck = null;
@@ -369,11 +384,8 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				return Satisfiability.SATISFIED;
 			return Satisfiability.UNKNOWN;
 		case COMPARISON_LT:
-			firstBound = new Interval(null, right.high == null ? null : right.high -1);
-			secondBound = new Interval(left.low == null ?  null : left.low - 1, null);
-
-			firstBound = new Interval(null, right.high);
-			secondBound = new Interval(left.low, null);
+			firstBound = right.high == null ? top() : new Interval(null, right.high - 1);
+			secondBound = left.low == null ? top() : new Interval(left.low + 1, null);
 
 			firstCheck = null;
 			secondCheck = null;
@@ -513,7 +525,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((high == null) ? 0 : high.hashCode());
-		result = prime * result + (isBottom ? 1231 : 1237);
 		result = prime * result + (isTop ? 1231 : 1237);
 		result = prime * result + ((low == null) ? 0 : low.hashCode());
 		return result;
@@ -533,8 +544,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				return false;
 		} else if (!high.equals(other.high))
 			return false;
-		if (isBottom != other.isBottom)
-			return false;
 		if (isTop != other.isTop)
 			return false;
 		if (low == null) {
@@ -549,6 +558,14 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 	protected ValueEnvironment<Interval> assumeBinaryExpression(
 			ValueEnvironment<Interval> environment, BinaryOperator operator, ValueExpression left,
 			ValueExpression right, ProgramPoint pp) throws SemanticException {
+
+		Map<Identifier, Interval> map = null;
+
+		if (environment.getMap() == null)
+			map = new HashMap<Identifier, Interval>();
+		else
+			map = new HashMap<>(environment.getMap());
+
 		switch (operator) {
 		case COMPARISON_EQ:
 			if (left instanceof Identifier)
@@ -562,12 +579,10 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				if (rightEval.lowIsMinusInfinity())
 					return environment;
 
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval bound = new Interval(rightEval.low, null);
 				map.put((Identifier) left, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);
 			} else if (right instanceof Identifier) {
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval leftEval = eval(left, environment, pp);
 				Interval bound = leftEval.lowIsMinusInfinity() ? leftEval : new Interval(null, leftEval.low);
 				map.put((Identifier) right, bound);
@@ -580,12 +595,10 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				if (rightEval.lowIsMinusInfinity())
 					return environment;
 
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval bound = new Interval(rightEval.low + 1, null);
 				map.put((Identifier) left, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);
 			} else if (right instanceof Identifier) {
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval leftEval = eval(left, environment, pp);
 				Interval bound = leftEval.lowIsMinusInfinity() ? leftEval : new Interval(null, leftEval.low - 1);
 				map.put((Identifier) right, bound);
@@ -596,7 +609,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 			if (left instanceof Identifier) {
 				Interval rightEval = eval(right, environment, pp);
 				Interval bound = rightEval.lowIsMinusInfinity() ? rightEval : new Interval(null, rightEval.low);
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				map.put((Identifier) left, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);
 			} else if (right instanceof Identifier) {
@@ -604,7 +616,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				if (leftEval.lowIsMinusInfinity())
 					return environment;
 
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval bound = new Interval(leftEval.low, null);
 				map.put((Identifier) right, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);
@@ -614,7 +625,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 			if (left instanceof Identifier) {
 				Interval rightEval = eval(right, environment, pp);
 				Interval bound = rightEval.lowIsMinusInfinity() ? rightEval : new Interval(null, rightEval.low - 1);
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				map.put((Identifier) left, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);
 			} else if (right instanceof Identifier) {
@@ -622,7 +632,6 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				if (leftEval.lowIsMinusInfinity())
 					return environment;
 
-				Map<Identifier, Interval> map = new HashMap<>(environment.getMap());
 				Interval bound = new Interval(leftEval.low + 1, null);
 				map.put((Identifier) right, bound);
 				return new ValueEnvironment<Interval>(bottom(), map);


### PR DESCRIPTION
**Description**
This pull request defines the satisfies methods for the ```Interval``` domain. In particular, it just defines the method ```satisfiesBinaryExpression```, since ```Interval``` cannot satisfy other types of symbolic expressions. The implementation of the ```satisfiesBinaryExpression``` method follows the definition reported [here](https://www-apr.lip6.fr/~mine/these/these-color.pdf), page 39.

Closes #82 
