### PR TITLE
Monolithic equals and hashCode methods, non-instance call matching and NativeCFG rewriting

### DIFF
--- a/lisa/src/main/java/it/unive/lisa/analysis/impl/heap/MonolithicHeap.java
+++ b/lisa/src/main/java/it/unive/lisa/analysis/impl/heap/MonolithicHeap.java
@@ -114,18 +114,12 @@ public class MonolithicHeap extends BaseHeapDomain<MonolithicHeap> {
 
 	@Override
 	public int hashCode() {
-		return MonolithicHeap.class.hashCode();
+		return System.identityHashCode(this);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		return true;
+		return this == obj;
 	}
 
 	private static class Rewriter extends BaseHeapDomain.Rewriter {

--- a/lisa/src/main/java/it/unive/lisa/callgraph/impl/intraproc/IntraproceduralCallGraph.java
+++ b/lisa/src/main/java/it/unive/lisa/callgraph/impl/intraproc/IntraproceduralCallGraph.java
@@ -100,7 +100,7 @@ public class IntraproceduralCallGraph implements CallGraph {
 			}
 		} else {
 			for (CodeMember cm : program.getAllCodeMembers())
-				if (cm.getDescriptor().isInstance() && cm.getDescriptor().getName().equals(call.getTargetName())
+				if (!cm.getDescriptor().isInstance() && cm.getDescriptor().getName().equals(call.getTargetName())
 						&& call.getStrategy().matches(cm.getDescriptor().getArgs(), call.getParameters()))
 					targets.add(cm);
 		}

--- a/lisa/src/main/java/it/unive/lisa/program/cfg/NativeCFG.java
+++ b/lisa/src/main/java/it/unive/lisa/program/cfg/NativeCFG.java
@@ -80,7 +80,7 @@ public class NativeCFG implements CodeMember {
 		pars[0] = original.getCFG();
 		pars[1] = original.getLocation();
 		for (int i = 0; i < params.length; i++)
-			pars[i + 4] = params[i];
+			pars[i + 2] = params[i];
 
 		try {
 			NativeCall instance = LiSAFactory.getInstance(construct, pars);


### PR DESCRIPTION
**Description**
Fixed `equals` and `hashCode` methods for `MonolithicHeap`. Fixes checking for `isInstance()` during non-instance call solving. Fixes `NativeCFG` rewriting.

**Fixed bugs**
Closes #91 
Closes #93 
Closes #94 