### PR TITLE
Filename sanitization for `FileManager`

### DIFF
--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
@@ -198,7 +198,7 @@ public class FileManager {
 		for (int i = 0; i < len; i++) {
 			int c = name.codePointAt(i);
 			// 57 is / and 92 is \
-			if ((keepDirSeparator && (c == 57 || c == 92)) 
+			if ((keepDirSeparator && (c == 57 || c == 92))
 					|| Arrays.binarySearch(illegalChars, c) < 0)
 				cleanName.appendCodePoint(c);
 			else

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
@@ -7,6 +7,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
@@ -61,6 +62,24 @@ public class FileManager {
 	}
 
 	/**
+	 * Creates a UTF-8 encoded file with the given name. If name is a path, all
+	 * missing directories will be created as well. The given name will be
+	 * joined with the workdir used to initialize this file manager, thus
+	 * raising an exception if {@code name} is absolute. {@code filler} will
+	 * then be used to write to the writer.
+	 * 
+	 * @param path   the sub-path, relative to the workdir, where the file
+	 *                   should be created
+	 * @param name   the name of the file to create
+	 * @param filler the callback to write to the file
+	 * 
+	 * @throws IOException if something goes wrong while creating the file
+	 */
+	public void mkOutputFile(String path, String name, WriteAction filler) throws IOException {
+		mkOutputFile(path, name, false, filler);
+	}
+
+	/**
 	 * Creates a UTF-8 encoded file with the given name, appending the
 	 * {@code dot} extension. If name is a path, all missing directories will be
 	 * created as well. The name will be stripped of any characters that might
@@ -76,6 +95,26 @@ public class FileManager {
 	 */
 	public void mkDotFile(String name, WriteAction filler) throws IOException {
 		mkOutputFile(cleanupForDotFile(name) + ".dot", false, filler);
+	}
+
+	/**
+	 * Creates a UTF-8 encoded file with the given name, appending the
+	 * {@code dot} extension. If name is a path, all missing directories will be
+	 * created as well. The name will be stripped of any characters that might
+	 * cause problems in the file name. The given name will be joined with the
+	 * workdir used to initialize this file manager, thus raising an exception
+	 * if {@code name} is absolute. {@code filler} will then be used to write to
+	 * the writer.
+	 * 
+	 * @param path   the sub-path, relative to the workdir, where the file
+	 *                   should be created
+	 * @param name   the name of the file to create
+	 * @param filler the callback to write to the file
+	 * 
+	 * @throws IOException if something goes wrong while creating the file
+	 */
+	public void mkDotFile(String path, String name, WriteAction filler) throws IOException {
+		mkOutputFile(path, cleanupForDotFile(name) + ".dot", false, filler);
 	}
 
 	/**
@@ -112,18 +151,61 @@ public class FileManager {
 	 *                         the file
 	 */
 	public void mkOutputFile(String name, boolean bom, WriteAction filler) throws IOException {
-		File file = new File(workdir, name);
+		mkOutputFile(null, name, bom, filler);
+	}
 
-		File parent = file.getAbsoluteFile().getParentFile();
+	/**
+	 * Creates a UTF-8 encoded file with the given name. If name is a path, all
+	 * missing directories will be created as well. The given name will be
+	 * joined with the workdir used to initialize this file manager, thus
+	 * raising an exception if {@code name} is absolute. {@code filler} will
+	 * then be used to write to the writer.
+	 * 
+	 * @param path   the sub-path, relative to the workdir, where the file
+	 *                   should be created
+	 * @param name   the name of the file to create
+	 * @param bom    if {@code true}, the bom marker {@code \ufeff} will be
+	 *                   written to the file
+	 * @param filler the callback to write to the file
+	 * 
+	 * @throws IOException if something goes wrong while creating or writing to
+	 *                         the file
+	 */
+	public void mkOutputFile(String path, String name, boolean bom, WriteAction filler) throws IOException {
+		File parent = workdir;
+		if (path != null)
+			parent = new File(workdir, cleanFileName(path, true));
+		File file = new File(parent, cleanFileName(name, false));
+
 		if (!parent.exists() && !parent.mkdirs())
 			throw new IOException("Unable to create directory structure for " + file);
 
-		createdFiles.add(name);
+		createdFiles.add(workdir.toPath().relativize(file.toPath()).toString());
 		try (Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8.newEncoder())) {
 			if (bom)
 				writer.write('\ufeff');
 			filler.perform(writer);
 		}
+	}
+
+	private final static int[] illegalChars = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+			20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 42, 47, 58, 60, 62, 63, 92, 124 };
+
+	private static String cleanFileName(String name, boolean keepDirSeparator) {
+		// https://stackoverflow.com/questions/1155107/is-there-a-cross-platform-java-method-to-remove-filename-special-chars
+		StringBuilder cleanName = new StringBuilder();
+		int len = name.codePointCount(0, name.length());
+		for (int i = 0; i < len; i++) {
+			int c = name.codePointAt(i);
+			// 57 is / and 92 is \
+			if ((keepDirSeparator && (c == 57 || c == 92)) 
+					|| Arrays.binarySearch(illegalChars, c) < 0)
+				cleanName.appendCodePoint(c);
+			else
+				cleanName.appendCodePoint('_');
+
+		}
+		return cleanName.toString();
 	}
 
 	private static String cleanupForDotFile(String name) {

--- a/lisa/lisa-sdk/src/test/java/it/unive/lisa/util/file/FileManagerTest.java
+++ b/lisa/lisa-sdk/src/test/java/it/unive/lisa/util/file/FileManagerTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/lisa/lisa-sdk/src/test/java/it/unive/lisa/util/file/FileManagerTest.java
+++ b/lisa/lisa-sdk/src/test/java/it/unive/lisa/util/file/FileManagerTest.java
@@ -1,9 +1,11 @@
 package it.unive.lisa.util.file;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,8 +52,9 @@ public class FileManagerTest {
 	@Test
 	public void testCreateFile() {
 		FileManager manager = new FileManager(TESTDIR);
+		String name = "foo.txt";
 		try {
-			manager.mkOutputFile("foo.txt", w -> w.write("foo"));
+			manager.mkOutputFile(name, w -> w.write("foo"));
 		} catch (IOException e) {
 			e.printStackTrace();
 			fail("The file has not been created");
@@ -61,16 +64,20 @@ public class FileManagerTest {
 		if (!dir.exists())
 			fail("The working directory has not been created");
 
-		File file = new File(dir, "foo.txt");
+		File file = new File(dir, name);
 		if (!file.exists())
 			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(), name);
 	}
 
 	@Test
 	public void testCreateFileWithBom() {
 		FileManager manager = new FileManager(TESTDIR);
+		String name = "foo.txt";
 		try {
-			manager.mkOutputFile("foo.txt", true, w -> w.write("foo"));
+			manager.mkOutputFile(name, true, w -> w.write("foo"));
 		} catch (IOException e) {
 			e.printStackTrace();
 			fail("The file has not been created");
@@ -80,16 +87,19 @@ public class FileManagerTest {
 		if (!dir.exists())
 			fail("The working directory has not been created");
 
-		File file = new File(dir, "foo.txt");
+		File file = new File(dir, name);
 		if (!file.exists())
 			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(), name);
 	}
 
 	@Test
 	public void testCreateFileInSubfolder() {
 		FileManager manager = new FileManager(TESTDIR);
 		try {
-			manager.mkOutputFile("sub/foo.txt", w -> w.write("foo"));
+			manager.mkOutputFile("sub", "foo.txt", w -> w.write("foo"));
 		} catch (IOException e) {
 			e.printStackTrace();
 			fail("The file has not been created");
@@ -106,6 +116,10 @@ public class FileManagerTest {
 		File file = new File(sub, "foo.txt");
 		if (!file.exists())
 			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(),
+				"sub" + File.separatorChar + "foo.txt");
 	}
 
 	@Test
@@ -125,5 +139,55 @@ public class FileManagerTest {
 		File file = new File(dir, "foo()__bar.jar.dot");
 		if (!file.exists())
 			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(),
+				file.getName());
+	}
+
+	@Test
+	public void testFileNameWithUnixSlashes() {
+		FileManager manager = new FileManager(TESTDIR);
+		try {
+			manager.mkOutputFile("foo/bar.txt", w -> w.write("foo"));
+		} catch (IOException e) {
+			e.printStackTrace();
+			fail("The file has not been created");
+		}
+
+		File dir = new File(TESTDIR);
+		if (!dir.exists())
+			fail("The working directory has not been created");
+
+		File file = new File(dir, "foo_bar.txt");
+		if (!file.exists())
+			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(),
+				file.getName());
+	}
+
+	@Test
+	public void testFileNameWithWindowsSlashes() {
+		FileManager manager = new FileManager(TESTDIR);
+		try {
+			manager.mkOutputFile("foo\\bar.txt", w -> w.write("foo"));
+		} catch (IOException e) {
+			e.printStackTrace();
+			fail("The file has not been created");
+		}
+
+		File dir = new File(TESTDIR);
+		if (!dir.exists())
+			fail("The working directory has not been created");
+
+		File file = new File(dir, "foo_bar.txt");
+		if (!file.exists())
+			fail("The file has not been created");
+
+		assertEquals("FileManager did not track the correct number of files", manager.createdFiles().size(), 1);
+		assertEquals("FileManager did not track the created file", manager.createdFiles().iterator().next(),
+				file.getName());
 	}
 }


### PR DESCRIPTION
**Description**
`FileManager` was implemented such that slashes in filenames were always considered intentional, meaning that a sub-directory needed to be created. This is not always the case: java bytecode signatures contain slashes, and if those signatures are used in file names (i.e. dot files) this caused unwanted creation of sub-folders.

**Fixed bugs**
Closes #130 