### PR TITLE
Updating to a more recent version of log4j

### DIFF
--- a/lisa/lisa-core/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
+++ b/lisa/lisa-core/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
@@ -30,6 +30,7 @@ import it.unive.lisa.analysis.representation.DomainRepresentation;
 import it.unive.lisa.analysis.representation.StringRepresentation;
 import it.unive.lisa.analysis.types.InferredTypes;
 import it.unive.lisa.analysis.value.ValueDomain;
+import it.unive.lisa.caches.Caches;
 import it.unive.lisa.imp.IMPFrontend;
 import it.unive.lisa.interprocedural.CFGResults;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -54,6 +55,7 @@ import it.unive.lisa.symbolic.value.Skip;
 import it.unive.lisa.symbolic.value.ValueExpression;
 import it.unive.lisa.symbolic.value.Variable;
 import it.unive.lisa.type.Type;
+import it.unive.lisa.type.Untyped;
 import it.unive.lisa.type.common.BoolType;
 import it.unive.lisa.type.common.StringType;
 import it.unive.lisa.util.collections.externalSet.ExternalSet;
@@ -129,7 +131,7 @@ public class SemanticsSanityTest {
 							throws SemanticException {
 				return entryState
 						.smallStepSemantics(
-								new Variable(getRuntimeTypes(), "fake", new SourceCodeLocation("unknown", 0, 0)), fake);
+								new Variable(Caches.types().mkSingletonSet(Untyped.INSTANCE), "fake", new SourceCodeLocation("unknown", 0, 0)), fake);
 			}
 		};
 	}

--- a/lisa/lisa-core/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
+++ b/lisa/lisa-core/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
@@ -131,7 +131,9 @@ public class SemanticsSanityTest {
 							throws SemanticException {
 				return entryState
 						.smallStepSemantics(
-								new Variable(Caches.types().mkSingletonSet(Untyped.INSTANCE), "fake", new SourceCodeLocation("unknown", 0, 0)), fake);
+								new Variable(Caches.types().mkSingletonSet(Untyped.INSTANCE), "fake",
+										new SourceCodeLocation("unknown", 0, 0)),
+								fake);
 			}
 		};
 	}

--- a/lisa/lisa-sdk/build.gradle
+++ b/lisa/lisa-sdk/build.gradle
@@ -13,9 +13,9 @@ dependencies {
 	api 'org.graphstream:gs-core:2.0'
     
 	// logging
-	api 'org.apache.logging.log4j:log4j-api:2.13.0'
-	runtimeOnly 'org.apache.logging.log4j:log4j-core:2.13.0'
-	runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.0'
+	api 'org.apache.logging.log4j:log4j-api:2.17.1'
+	runtimeOnly 'org.apache.logging.log4j:log4j-core:2.17.1'
+	runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
 	
 	// testing
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
**Description**
Upgrading to the most recent log4j version (2.17.1) to include fixes related to log4shell.

Closes #149 
