### PR TITLE
Restoring short-circuit capabilities

### DIFF
--- a/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPAddOrConcat.java
+++ b/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPAddOrConcat.java
@@ -4,6 +4,7 @@ package it.unive.lisa.imp.expressions;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -57,7 +58,8 @@ public class IMPAddOrConcat extends it.unive.lisa.program.cfg.statement.BinaryEx
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = state.bottom();
 		BinaryOperator op;

--- a/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPArrayAccess.java
+++ b/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPArrayAccess.java
@@ -3,6 +3,7 @@ package it.unive.lisa.imp.expressions;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -45,7 +46,8 @@ public class IMPArrayAccess extends BinaryExpression {
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 
 		if (!left.getDynamicType().isArrayType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewArray.java
+++ b/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewArray.java
@@ -3,6 +3,7 @@ package it.unive.lisa.imp.expressions;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -48,7 +49,8 @@ public class IMPNewArray extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		HeapAllocation alloc = new HeapAllocation(getRuntimeTypes(), getLocation());
 		AnalysisState<A, H, V> sem = state.smallStepSemantics(alloc, this);

--- a/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewObj.java
+++ b/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewObj.java
@@ -68,7 +68,7 @@ public class IMPNewObj extends NaryExpression {
 		UnresolvedCall call = new UnresolvedCall(getCFG(), getLocation(),
 				IMPFrontend.CALL_STRATEGY, true, getStaticType().toString(), fullExpressions);
 		call.setRuntimeTypes(getRuntimeTypes());
-		AnalysisState<A, H, V> sem = call.expressionSemantics(interprocedural, state, fullParams, null);
+		AnalysisState<A, H, V> sem = call.expressionSemantics(interprocedural, state, fullParams, expressions);
 
 		if (!call.getMetaVariables().isEmpty())
 			sem = sem.forgetIdentifiers(call.getMetaVariables());

--- a/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewObj.java
+++ b/lisa/lisa-imp/src/main/java/it/unive/lisa/imp/expressions/IMPNewObj.java
@@ -3,6 +3,7 @@ package it.unive.lisa.imp.expressions;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -54,7 +55,8 @@ public class IMPNewObj extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		HeapAllocation created = new HeapAllocation(getRuntimeTypes(), getLocation());
 
@@ -66,7 +68,7 @@ public class IMPNewObj extends NaryExpression {
 		UnresolvedCall call = new UnresolvedCall(getCFG(), getLocation(),
 				IMPFrontend.CALL_STRATEGY, true, getStaticType().toString(), fullExpressions);
 		call.setRuntimeTypes(getRuntimeTypes());
-		AnalysisState<A, H, V> sem = call.expressionSemantics(interprocedural, state, fullParams);
+		AnalysisState<A, H, V> sem = call.expressionSemantics(interprocedural, state, fullParams, null);
 
 		if (!call.getMetaVariables().isEmpty())
 			sem = sem.forgetIdentifiers(call.getMetaVariables());

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/Assignment.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/Assignment.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -99,7 +100,8 @@ public class Assignment extends BinaryExpression {
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		return state.assign(left, right, this);
 	}

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/BinaryExpression.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/BinaryExpression.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -116,12 +117,13 @@ public abstract class BinaryExpression extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = state.bottom();
 		for (SymbolicExpression left : params[0])
 			for (SymbolicExpression right : params[1])
-				result = result.lub(binarySemantics(interprocedural, state, left, right));
+				result = result.lub(binarySemantics(interprocedural, state, left, right, expressions));
 
 		return result;
 	}
@@ -143,6 +145,10 @@ public abstract class BinaryExpression extends NaryExpression {
 	 * @param right           the symbolic expression representing the computed
 	 *                            value of the second sub-expression of this
 	 *                            expression
+	 * @param expressions     the cache where analysis states of intermediate
+	 *                            expressions are stored and that can be
+	 *                            accessed to query for post-states of
+	 *                            parameters expressions
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this expression
@@ -155,6 +161,7 @@ public abstract class BinaryExpression extends NaryExpression {
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException;
 }

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/NaryExpression.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/NaryExpression.java
@@ -211,7 +211,7 @@ public abstract class NaryExpression extends Expression {
 
 		AnalysisState<A, H,
 				V> eval = order.evaluate(subExpressions, entryState, interprocedural, expressions, computed);
-		AnalysisState<A, H, V> result = expressionSemantics(interprocedural, eval, computed);
+		AnalysisState<A, H, V> result = expressionSemantics(interprocedural, eval, computed, expressions);
 
 		for (Expression sub : subExpressions)
 			if (!sub.getMetaVariables().isEmpty())
@@ -233,6 +233,10 @@ public abstract class NaryExpression extends Expression {
 	 * @param params          the symbolic expressions representing the computed
 	 *                            values of the sub-expressions of this
 	 *                            expression
+	 * @param expressions     the cache where analysis states of intermediate
+	 *                            expressions are stored and that can be
+	 *                            accessed to query for post-states of
+	 *                            parameters expressions
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this expression
@@ -244,6 +248,6 @@ public abstract class NaryExpression extends Expression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params, StatementStore<A, H, V> expressions)
 					throws SemanticException;
 }

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/TernaryExpression.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/TernaryExpression.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -131,13 +132,14 @@ public abstract class TernaryExpression extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = state.bottom();
 		for (SymbolicExpression left : params[0])
 			for (SymbolicExpression middle : params[1])
 				for (SymbolicExpression right : params[2])
-					result = result.lub(ternarySemantics(interprocedural, state, left, middle, right));
+					result = result.lub(ternarySemantics(interprocedural, state, left, middle, right, expressions));
 
 		return result;
 	}
@@ -162,6 +164,10 @@ public abstract class TernaryExpression extends NaryExpression {
 	 * @param right           the symbolic expression representing the computed
 	 *                            value of the third sub-expression of this
 	 *                            expression
+	 * @param expressions     the cache where analysis states of intermediate
+	 *                            expressions are stored and that can be
+	 *                            accessed to query for post-states of
+	 *                            parameters expressions
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this expression
@@ -175,6 +181,7 @@ public abstract class TernaryExpression extends NaryExpression {
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
 					SymbolicExpression middle,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException;
 }

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/UnaryExpression.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/UnaryExpression.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -105,11 +106,12 @@ public abstract class UnaryExpression extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = state.bottom();
 		for (SymbolicExpression expr : params[0])
-			result = result.lub(unarySemantics(interprocedural, state, expr));
+			result = result.lub(unarySemantics(interprocedural, state, expr, expressions));
 		return result;
 	}
 
@@ -126,6 +128,10 @@ public abstract class UnaryExpression extends NaryExpression {
 	 * @param state           the state where the expression is to be evaluated
 	 * @param expr            the symbolic expressions representing the computed
 	 *                            value of the sub-expression of this expression
+	 * @param expressions     the cache where analysis states of intermediate
+	 *                            expressions are stored and that can be
+	 *                            accessed to query for post-states of
+	 *                            parameters expressions
 	 * 
 	 * @return the {@link AnalysisState} representing the abstract result of the
 	 *             execution of this expression
@@ -137,6 +143,7 @@ public abstract class UnaryExpression extends NaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					SymbolicExpression expr)
+					SymbolicExpression expr,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException;
 }

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/CallWithResult.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/CallWithResult.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.call;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -94,7 +95,8 @@ public abstract class CallWithResult extends Call implements MetaVariableCreator
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// the stack has to be empty
 		state = new AnalysisState<>(state.getState(), new ExpressionSet<>());

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.call;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -192,7 +193,8 @@ public class HybridCall extends Call {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		AnalysisState<A, H, V> result = state.bottom();
 
@@ -201,14 +203,14 @@ public class HybridCall extends Call {
 			CFGCall cfgcall = new CFGCall(getCFG(), getLocation(), getConstructName(), targets, parameters);
 			cfgcall.setRuntimeTypes(getRuntimeTypes());
 			cfgcall.setSource(getSource());
-			result = cfgcall.expressionSemantics(interprocedural, state, params);
+			result = cfgcall.expressionSemantics(interprocedural, state, params, null);
 			getMetaVariables().addAll(cfgcall.getMetaVariables());
 		}
 
 		for (NativeCFG nat : nativeTargets)
 			try {
 				NaryExpression rewritten = nat.rewrite(this, parameters);
-				result = result.lub(rewritten.expressionSemantics(interprocedural, state, params));
+				result = result.lub(rewritten.expressionSemantics(interprocedural, state, params, null));
 				getMetaVariables().addAll(rewritten.getMetaVariables());
 			} catch (CallResolutionException e) {
 				throw new SemanticException("Unable to resolve call " + this, e);

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
@@ -203,14 +203,14 @@ public class HybridCall extends Call {
 			CFGCall cfgcall = new CFGCall(getCFG(), getLocation(), getConstructName(), targets, parameters);
 			cfgcall.setRuntimeTypes(getRuntimeTypes());
 			cfgcall.setSource(getSource());
-			result = cfgcall.expressionSemantics(interprocedural, state, params, null);
+			result = cfgcall.expressionSemantics(interprocedural, state, params, expressions);
 			getMetaVariables().addAll(cfgcall.getMetaVariables());
 		}
 
 		for (NativeCFG nat : nativeTargets)
 			try {
 				NaryExpression rewritten = nat.rewrite(this, parameters);
-				result = result.lub(rewritten.expressionSemantics(interprocedural, state, params, null));
+				result = result.lub(rewritten.expressionSemantics(interprocedural, state, params, expressions));
 				getMetaVariables().addAll(rewritten.getMetaVariables());
 			} catch (CallResolutionException e) {
 				throw new SemanticException("Unable to resolve call " + this, e);

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/UnresolvedCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/UnresolvedCall.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.call;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.lattices.ExpressionSet;
 import it.unive.lisa.analysis.value.ValueDomain;
@@ -184,7 +185,8 @@ public class UnresolvedCall extends Call {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> expressionSemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					ExpressionSet<SymbolicExpression>[] params)
+					ExpressionSet<SymbolicExpression>[] params,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		Call resolved;
 		try {
@@ -194,7 +196,7 @@ public class UnresolvedCall extends Call {
 		}
 		resolved.setRuntimeTypes(getRuntimeTypes());
 		AnalysisState<A, H,
-				V> result = resolved.expressionSemantics(interprocedural, state, params);
+				V> result = resolved.expressionSemantics(interprocedural, state, params, null);
 		getMetaVariables().addAll(resolved.getMetaVariables());
 		return result;
 	}

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/UnresolvedCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/UnresolvedCall.java
@@ -195,8 +195,7 @@ public class UnresolvedCall extends Call {
 			throw new SemanticException("Unable to resolve call " + this, e);
 		}
 		resolved.setRuntimeTypes(getRuntimeTypes());
-		AnalysisState<A, H,
-				V> result = resolved.expressionSemantics(interprocedural, state, params, null);
+		AnalysisState<A, H, V> result = resolved.expressionSemantics(interprocedural, state, params, expressions);
 		getMetaVariables().addAll(resolved.getMetaVariables());
 		return result;
 	}

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/Equal.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/Equal.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -42,7 +43,8 @@ public class Equal extends it.unive.lisa.program.cfg.statement.BinaryExpression 
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		return state.smallStepSemantics(
 				new BinaryExpression(

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/GreaterOrEqual.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/GreaterOrEqual.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class GreaterOrEqual extends it.unive.lisa.program.cfg.statement.BinaryEx
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/GreaterThan.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/GreaterThan.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class GreaterThan extends it.unive.lisa.program.cfg.statement.BinaryExpre
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/LessOrEqual.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/LessOrEqual.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class LessOrEqual extends it.unive.lisa.program.cfg.statement.BinaryExpre
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/LessThan.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/LessThan.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class LessThan extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/NotEqual.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/comparison/NotEqual.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.comparison;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -42,7 +43,8 @@ public class NotEqual extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		return state.smallStepSemantics(
 				new BinaryExpression(

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/And.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/And.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.logic;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class And extends it.unive.lisa.program.cfg.statement.BinaryExpression {
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isBooleanType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/Not.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/Not.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.logic;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -42,7 +43,8 @@ public class Not extends it.unive.lisa.program.cfg.statement.UnaryExpression {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					SymbolicExpression expr)
+					SymbolicExpression expr,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!expr.getDynamicType().isBooleanType() && !expr.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/Or.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/logic/Or.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.logic;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -44,7 +45,8 @@ public class Or extends it.unive.lisa.program.cfg.statement.BinaryExpression {
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isBooleanType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Addition.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Addition.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -43,7 +44,8 @@ public class Addition extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Division.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Division.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -43,7 +44,8 @@ public class Division extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Multiplication.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Multiplication.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -43,7 +44,8 @@ public class Multiplication extends it.unive.lisa.program.cfg.statement.BinaryEx
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Negation.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Negation.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -40,7 +41,8 @@ public class Negation extends it.unive.lisa.program.cfg.statement.UnaryExpressio
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					SymbolicExpression expr)
+					SymbolicExpression expr,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!expr.getDynamicType().isNumericType() && !expr.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Remainder.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Remainder.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -43,7 +44,8 @@ public class Remainder extends it.unive.lisa.program.cfg.statement.BinaryExpress
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Subtraction.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Subtraction.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.numeric;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.interprocedural.InterproceduralAnalysis;
@@ -43,7 +44,8 @@ public class Subtraction extends it.unive.lisa.program.cfg.statement.BinaryExpre
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isNumericType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Concat.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Concat.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -65,7 +66,8 @@ public class Concat extends it.unive.lisa.program.cfg.statement.BinaryExpression
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Contains.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Contains.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -66,7 +67,8 @@ public class Contains extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/EndsWith.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/EndsWith.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -66,7 +67,8 @@ public class EndsWith extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Equals.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Equals.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -66,7 +67,8 @@ public class Equals extends it.unive.lisa.program.cfg.statement.BinaryExpression
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/IndexOf.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/IndexOf.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -66,7 +67,8 @@ public class IndexOf extends it.unive.lisa.program.cfg.statement.BinaryExpressio
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Length.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Length.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -64,7 +65,8 @@ public class Length extends it.unive.lisa.program.cfg.statement.UnaryExpression 
 			V extends ValueDomain<V>> AnalysisState<A, H, V> unarySemantics(
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
-					SymbolicExpression expr)
+					SymbolicExpression expr,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!expr.getDynamicType().isStringType() && !expr.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Replace.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Replace.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -67,7 +68,8 @@ public class Replace extends it.unive.lisa.program.cfg.statement.TernaryExpressi
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
 					SymbolicExpression middle,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/StartsWith.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/StartsWith.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -66,7 +67,8 @@ public class StartsWith extends it.unive.lisa.program.cfg.statement.BinaryExpres
 					InterproceduralAnalysis<A, H, V> interprocedural,
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Substring.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/string/Substring.java
@@ -3,6 +3,7 @@ package it.unive.lisa.program.cfg.statement.string;
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
+import it.unive.lisa.analysis.StatementStore;
 import it.unive.lisa.analysis.heap.HeapDomain;
 import it.unive.lisa.analysis.value.ValueDomain;
 import it.unive.lisa.caches.Caches;
@@ -68,7 +69,8 @@ public class Substring extends it.unive.lisa.program.cfg.statement.TernaryExpres
 					AnalysisState<A, H, V> state,
 					SymbolicExpression left,
 					SymbolicExpression middle,
-					SymbolicExpression right)
+					SymbolicExpression right,
+					StatementStore<A, H, V> expressions)
 					throws SemanticException {
 		// we allow untyped for the type inference phase
 		if (!left.getDynamicType().isStringType() && !left.getDynamicType().isUntyped())


### PR DESCRIPTION
**Description**
Passing the `StatementStore` holding intermediate expressions' abstract states to `expressionSemantics`, `unarySemantics`, `binarySemantics`, and `ternarySemantics` to enable short-circuiting by querying the store for the expressions' post states.

**Implemented features**
Closes #165 