### PR TITLE
CFG validation, AnalysisState initialization, PythonLikeMatchingStrategy and HybridCall fixes

### DIFF
--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/CFGWithAnalysisResults.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/CFGWithAnalysisResults.java
@@ -158,12 +158,9 @@ public class CFGWithAnalysisResults<A extends AbstractState<A, H, V>, H extends 
 	}
 
 	private AnalysisState<A, H, V> lub(Collection<Statement> statements, boolean entry) throws SemanticException {
-		AnalysisState<A, H, V> result = null;
+		AnalysisState<A, H, V> result = entryStates.lattice.bottom();
 		for (Statement st : statements)
-			if (result == null)
-				result = entry ? getAnalysisStateBefore(st) : getAnalysisStateAfter(st);
-			else
-				result = result.lub(entry ? getAnalysisStateBefore(st) : getAnalysisStateAfter(st));
+			result = result.lub(entry ? getAnalysisStateBefore(st) : getAnalysisStateAfter(st));
 		return result;
 
 	}

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/edge/FalseEdge.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/edge/FalseEdge.java
@@ -42,16 +42,13 @@ public class FalseEdge extends Edge {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> traverse(
 					AnalysisState<A, H, V> sourceState) throws SemanticException {
 		ExpressionSet<SymbolicExpression> exprs = sourceState.getComputedExpressions();
-		AnalysisState<A, H, V> result = null;
+		AnalysisState<A, H, V> result = sourceState.bottom();
 		for (SymbolicExpression expr : exprs) {
 			AnalysisState<A, H, V> tmp = sourceState
 					.assume(new UnaryExpression(expr.getTypes(), expr, LogicalNegation.INSTANCE,
 							expr.getCodeLocation()),
 							getSource());
-			if (result == null)
-				result = tmp;
-			else
-				result = result.lub(tmp);
+			result = result.lub(tmp);
 		}
 		return result;
 	}

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/edge/TrueEdge.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/edge/TrueEdge.java
@@ -39,14 +39,9 @@ public class TrueEdge extends Edge {
 			V extends ValueDomain<V>> AnalysisState<A, H, V> traverse(
 					AnalysisState<A, H, V> sourceState) throws SemanticException {
 		ExpressionSet<SymbolicExpression> exprs = sourceState.getComputedExpressions();
-		AnalysisState<A, H, V> result = null;
-		for (SymbolicExpression expr : exprs) {
-			AnalysisState<A, H, V> tmp = sourceState.assume(expr, getSource());
-			if (result == null)
-				result = tmp;
-			else
-				result = result.lub(tmp);
-		}
+		AnalysisState<A, H, V> result = sourceState.bottom();
+		for (SymbolicExpression expr : exprs)
+			result = result.lub(sourceState.assume(expr, getSource()));
 		return result;
 	}
 

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
@@ -1,9 +1,5 @@
 package it.unive.lisa.program.cfg.statement.call;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Objects;
-
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
@@ -25,6 +21,9 @@ import it.unive.lisa.program.cfg.statement.evaluation.LeftToRightEvaluation;
 import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.type.Type;
 import it.unive.lisa.type.Untyped;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * A call to one or more {@link CFG}s and/or {@link NativeCFG}s under analysis.

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/HybridCall.java
@@ -1,5 +1,9 @@
 package it.unive.lisa.program.cfg.statement.call;
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+
 import it.unive.lisa.analysis.AbstractState;
 import it.unive.lisa.analysis.AnalysisState;
 import it.unive.lisa.analysis.SemanticException;
@@ -12,7 +16,6 @@ import it.unive.lisa.interprocedural.callgraph.CallResolutionException;
 import it.unive.lisa.program.cfg.CFG;
 import it.unive.lisa.program.cfg.CodeLocation;
 import it.unive.lisa.program.cfg.NativeCFG;
-import it.unive.lisa.program.cfg.Parameter;
 import it.unive.lisa.program.cfg.statement.Expression;
 import it.unive.lisa.program.cfg.statement.NaryExpression;
 import it.unive.lisa.program.cfg.statement.call.assignment.ParameterAssigningStrategy;
@@ -22,9 +25,6 @@ import it.unive.lisa.program.cfg.statement.evaluation.LeftToRightEvaluation;
 import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.type.Type;
 import it.unive.lisa.type.Untyped;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Objects;
 
 /**
  * A call to one or more {@link CFG}s and/or {@link NativeCFG}s under analysis.
@@ -270,10 +270,7 @@ public class HybridCall extends Call {
 		for (NativeCFG nat : nativeTargets)
 			try {
 				NaryExpression rewritten = nat.rewrite(this, parameters);
-				Parameter[] formals = nat.getDescriptor().getFormals();
-				AnalysisState<A, H, V> prepared = getAssigningStrategy().prepare(this, state, interprocedural,
-						expressions, formals, params);
-				result = result.lub(rewritten.expressionSemantics(interprocedural, prepared, params, expressions));
+				result = result.lub(rewritten.expressionSemantics(interprocedural, state, params, expressions));
 				getMetaVariables().addAll(rewritten.getMetaVariables());
 			} catch (CallResolutionException e) {
 				throw new SemanticException("Unable to resolve call " + this, e);

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/resolution/PythonLikeMatchingStrategy.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/call/resolution/PythonLikeMatchingStrategy.java
@@ -57,6 +57,10 @@ public class PythonLikeMatchingStrategy implements ParameterMatchingStrategy {
 
 	@Override
 	public boolean matches(Call call, Parameter[] formals, Expression[] actuals) {
+		if (formals.length < actuals.length)
+			// too many arguments!
+			return false;
+
 		Expression[] slots = new Expression[formals.length];
 		int pos = 0;
 

--- a/lisa/lisa-sdk/src/test/java/it/unive/lisa/program/cfg/CFGSimplificationTest.java
+++ b/lisa/lisa-sdk/src/test/java/it/unive/lisa/program/cfg/CFGSimplificationTest.java
@@ -55,10 +55,7 @@ public class CFGSimplificationTest {
 
 		second.addEdge(new SequentialEdge(assign, ret));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 	}
 
@@ -92,10 +89,7 @@ public class CFGSimplificationTest {
 
 		second.addEdge(new SequentialEdge(assign, ret));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 	}
 
@@ -159,10 +153,7 @@ public class CFGSimplificationTest {
 		second.addControlFlowStructure(
 				new IfThenElse(second.getAdjacencyMatrix(), gt, ret, tbranch.getNodes(), fbranch.getNodes()));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 		ControlFlowStructure exp = second.getControlFlowStructures().iterator().next();
 		ControlFlowStructure act = first.getControlFlowStructures().iterator().next();
@@ -197,10 +188,7 @@ public class CFGSimplificationTest {
 
 		second.addEdge(new SequentialEdge(assign, ret));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 	}
 
@@ -232,10 +220,7 @@ public class CFGSimplificationTest {
 
 		second.addEdge(new SequentialEdge(assign, ret));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 	}
 
@@ -270,10 +255,7 @@ public class CFGSimplificationTest {
 
 		second.addEdge(new SequentialEdge(assign1, assign2));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 	}
 
@@ -331,10 +313,7 @@ public class CFGSimplificationTest {
 		second.addControlFlowStructure(
 				new IfThenElse(second.getAdjacencyMatrix(), assign1, null, tbranch.getNodes(), fbranch.getNodes()));
 
-		first.validate();
-		second.validate();
 		first.simplify();
-		first.validate();
 		assertTrue("Different CFGs", second.isEqualTo(first));
 		ControlFlowStructure exp = second.getControlFlowStructures().iterator().next();
 		ControlFlowStructure act = first.getControlFlowStructures().iterator().next();


### PR DESCRIPTION
**Description**
Removing assignments of analysis states to `null` and checking for invalid `CFG`s that are missing execution stopping statements along all paths. This also fixes `PythonLikeMatchingStrategy`'s matching algorithm.

**Fixed bugs**
Closes #170 
Closes #171 
Closes #173 