### PR TITLE
Identifiers removal by predicate

### DIFF
--- a/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/combination/CartesianProduct.java
+++ b/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/combination/CartesianProduct.java
@@ -10,6 +10,7 @@ import it.unive.lisa.analysis.representation.ListRepresentation;
 import it.unive.lisa.program.cfg.ProgramPoint;
 import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.symbolic.value.Identifier;
+import java.util.function.Predicate;
 
 /**
  * A generic Cartesian product abstract domain between two non-communicating
@@ -158,6 +159,13 @@ public abstract class CartesianProduct<C extends CartesianProduct<C, T1, T2, E, 
 	public C forgetIdentifier(Identifier id) throws SemanticException {
 		T1 newLeft = left.forgetIdentifier(id);
 		T2 newRight = right.forgetIdentifier(id);
+		return mk(newLeft, newRight);
+	}
+
+	@Override
+	public C forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		T1 newLeft = left.forgetIdentifiersIf(test);
+		T2 newRight = right.forgetIdentifiersIf(test);
 		return mk(newLeft, newRight);
 	}
 

--- a/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/MonolithicHeap.java
+++ b/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/MonolithicHeap.java
@@ -23,6 +23,7 @@ import it.unive.lisa.type.Untyped;
 import it.unive.lisa.util.collections.externalSet.ExternalSet;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * A monolithic heap implementation that abstracts all heap locations to a
@@ -80,6 +81,11 @@ public class MonolithicHeap extends BaseHeapDomain<MonolithicHeap> {
 
 	@Override
 	public MonolithicHeap forgetIdentifier(Identifier id) throws SemanticException {
+		return this;
+	}
+
+	@Override
+	public MonolithicHeap forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
 		return this;
 	}
 

--- a/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/TypeBasedHeap.java
+++ b/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/TypeBasedHeap.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.apache.commons.collections4.SetUtils;
 
 /**
@@ -75,6 +76,11 @@ public class TypeBasedHeap extends BaseHeapDomain<TypeBasedHeap> {
 
 	@Override
 	public TypeBasedHeap forgetIdentifier(Identifier id) throws SemanticException {
+		return this;
+	}
+
+	@Override
+	public TypeBasedHeap forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
 		return this;
 	}
 

--- a/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/pointbased/PointBasedHeap.java
+++ b/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/heap/pointbased/PointBasedHeap.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A field-insensitive point-based heap implementation that abstracts heap
@@ -111,6 +112,11 @@ public class PointBasedHeap extends BaseHeapDomain<PointBasedHeap> {
 	@Override
 	public PointBasedHeap forgetIdentifier(Identifier id) throws SemanticException {
 		return from(new PointBasedHeap(heapEnv.forgetIdentifier(id)));
+	}
+
+	@Override
+	public PointBasedHeap forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		return from(new PointBasedHeap(heapEnv.forgetIdentifiersIf(test)));
 	}
 
 	@Override

--- a/lisa/lisa-core/src/test/java/it/unive/lisa/analysis/value/SubstitutionTest.java
+++ b/lisa/lisa-core/src/test/java/it/unive/lisa/analysis/value/SubstitutionTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Predicate;
 import org.junit.Test;
 
 public class SubstitutionTest {
@@ -63,6 +64,11 @@ public class SubstitutionTest {
 			Collector rem = new Collector(this);
 			rem.removed.elements().add(id);
 			return rem;
+		}
+
+		@Override
+		public Collector forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+			return null;
 		}
 
 		@Override

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/AnalysisState.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/AnalysisState.java
@@ -15,6 +15,7 @@ import it.unive.lisa.symbolic.value.ValueExpression;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * The abstract analysis state at a given program point. An analysis state is
@@ -269,6 +270,11 @@ public class AnalysisState<A extends AbstractState<A, H, V, T>,
 	@Override
 	public AnalysisState<A, H, V, T> forgetIdentifier(Identifier id) throws SemanticException {
 		return new AnalysisState<>(state.forgetIdentifier(id), computedExpressions, aliasing);
+	}
+
+	@Override
+	public AnalysisState<A, H, V, T> forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		return new AnalysisState<>(state.forgetIdentifiersIf(test), computedExpressions, aliasing);
 	}
 
 	@Override

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/SemanticDomain.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/SemanticDomain.java
@@ -4,6 +4,7 @@ import it.unive.lisa.analysis.representation.DomainRepresentation;
 import it.unive.lisa.program.cfg.ProgramPoint;
 import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.symbolic.value.Identifier;
+import java.util.function.Predicate;
 
 /**
  * A domain able to determine how abstract information evolves thanks to the
@@ -77,6 +78,19 @@ public interface SemanticDomain<D extends SemanticDomain<D, E, I>, E extends Sym
 	 * @throws SemanticException if an error occurs during the computation
 	 */
 	D forgetIdentifier(Identifier id) throws SemanticException;
+
+	/**
+	 * Forgets all {@link Identifier}s that match the given predicate. This
+	 * means that all information regarding the those identifiers will be lost.
+	 * This method should be invoked whenever an identifier gets out of scope.
+	 * 
+	 * @param test the test to identify the targets of the removal
+	 * 
+	 * @return the semantic domain without information about the ids
+	 * 
+	 * @throws SemanticException if an error occurs during the computation
+	 */
+	D forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException;
 
 	/**
 	 * Forgets all the given {@link Identifier}s. The default implementation of

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/SimpleAbstractState.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/SimpleAbstractState.java
@@ -13,6 +13,7 @@ import it.unive.lisa.symbolic.value.ValueExpression;
 import it.unive.lisa.type.Type;
 import it.unive.lisa.util.collections.externalSet.ExternalSet;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * An abstract state of the analysis, composed by a heap state modeling the
@@ -237,6 +238,14 @@ public class SimpleAbstractState<H extends HeapDomain<H>,
 				heapState.forgetIdentifier(id),
 				valueState.forgetIdentifier(id),
 				typeState.forgetIdentifier(id));
+	}
+
+	@Override
+	public SimpleAbstractState<H, V, T> forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		return new SimpleAbstractState<>(
+				heapState.forgetIdentifiersIf(test),
+				valueState.forgetIdentifiersIf(test),
+				typeState.forgetIdentifiersIf(test));
 	}
 
 	@Override

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/dataflow/DataflowDomain.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/dataflow/DataflowDomain.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 /**
  * A dataflow domain that collects instances of {@link DataflowElement}. A
@@ -129,6 +130,25 @@ public abstract class DataflowDomain<D extends DataflowDomain<D, E>, E extends D
 		Collection<E> toRemove = new LinkedList<>();
 		for (E e : elements)
 			if (e.getInvolvedIdentifiers().contains(id))
+				toRemove.add(e);
+
+		if (toRemove.isEmpty())
+			return (D) this;
+
+		Set<E> updated = new HashSet<>(elements);
+		updated.removeAll(toRemove);
+		return mk(domain, updated, false, false);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public D forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		if (isTop())
+			return (D) this;
+
+		Collection<E> toRemove = new LinkedList<>();
+		for (E e : elements)
+			if (e.getInvolvedIdentifiers().stream().anyMatch(test::test))
 				toRemove.add(e);
 
 		if (toRemove.isEmpty())

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/nonrelational/Environment.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/nonrelational/Environment.java
@@ -17,7 +17,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -287,6 +289,19 @@ public abstract class Environment<M extends Environment<M, E, T, V>,
 		M result = copy();
 		if (result.function.containsKey(id))
 			result.function.remove(id);
+
+		return result;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public M forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
+		if (isTop() || isBottom())
+			return (M) this;
+
+		M result = copy();
+		Set<Identifier> keys = result.function.keySet().stream().filter(test::test).collect(Collectors.toSet());
+		keys.forEach(result.function::remove);
 
 		return result;
 	}

--- a/lisa/lisa-sdk/src/test/java/it/unive/lisa/TestDomain.java
+++ b/lisa/lisa-sdk/src/test/java/it/unive/lisa/TestDomain.java
@@ -7,6 +7,7 @@ import it.unive.lisa.analysis.SemanticException;
 import it.unive.lisa.program.cfg.ProgramPoint;
 import it.unive.lisa.symbolic.SymbolicExpression;
 import it.unive.lisa.symbolic.value.Identifier;
+import java.util.function.Predicate;
 
 @SuppressWarnings("unchecked")
 public abstract class TestDomain<T extends TestDomain<T, E>, E extends SymbolicExpression> extends BaseLattice<T>
@@ -39,6 +40,11 @@ public abstract class TestDomain<T extends TestDomain<T, E>, E extends SymbolicE
 
 	@Override
 	public T forgetIdentifier(Identifier id) throws SemanticException {
+		return (T) this;
+	}
+
+	@Override
+	public T forgetIdentifiersIf(Predicate<Identifier> test) throws SemanticException {
 		return (T) this;
 	}
 


### PR DESCRIPTION
**Description**
Added `forgetIdentifiersIf(Predicate<Identifier)` to `SemanticDomain`.

**Implemented features**
Closes #208 
